### PR TITLE
Improve detect mime for html elements and static chunks

### DIFF
--- a/_build/data/transport.settings.php
+++ b/_build/data/transport.settings.php
@@ -82,5 +82,13 @@ $settings['height']->fromArray(array(
         'area' => 'general'
     ),'',true,true);
 
+$settings['html_elements_mime']= $modx->newObject('modSystemSetting');
+$settings['html_elements_mime']->fromArray(array(
+        'key' => 'ace.html_elements_mime',
+        'xtype' => 'textfield',
+        'value' => '',
+        'namespace' => 'ace',
+        'area' => 'general'
+    ),'',true,true);
 
 return $settings;

--- a/core/components/ace/elements/plugins/ace.plugin.php
+++ b/core/components/ace/elements/plugins/ace.plugin.php
@@ -75,7 +75,10 @@ switch ($modx->event->name) {
     case 'OnChunkFormPrerender':
         $field = 'modx-chunk-snippet';
         if ($modx->controller->chunk && $modx->controller->chunk->isStatic()) {
-            $extension = pathinfo($modx->controller->chunk->getSourceFile(), PATHINFO_EXTENSION);
+            $extension = pathinfo($modx->controller->chunk->name, PATHINFO_EXTENSION);
+            if(!$extension||!isset($extensionMap[$extension])){
+                $extension = pathinfo($modx->controller->chunk->getSourceFile(), PATHINFO_EXTENSION);
+            }
             $mimeType = isset($extensionMap[$extension]) ? $extensionMap[$extension] : 'text/plain';
         } else {
             $mimeType = $html_elements_mime;

--- a/core/components/ace/elements/plugins/ace.plugin.php
+++ b/core/components/ace/elements/plugins/ace.plugin.php
@@ -44,6 +44,22 @@ $extensionMap = array(
     'twig'  => 'text/x-twig'
 );
 
+// Define default mime for html elements(templates, chunks and html resources)
+$html_elements_mime=$modx->getOption('ace.html_elements_mime',null,false);
+if(!$html_elements_mime){
+    // this may deprecated in future because components may set ace.html_elements_mime option now
+    switch (true) {
+        case $modx->getOption('twiggy_class'):
+            $html_elements_mime = 'text/x-twig';
+            break;
+        case $modx->getOption('pdotools_fenom_parser'):
+            $html_elements_mime = 'text/x-smarty';
+            break;
+        default:
+            $html_elements_mime = 'text/html';
+    }
+}
+
 // Defines wether we should highlight modx tags
 $modxTags = false;
 switch ($modx->event->name) {
@@ -54,19 +70,7 @@ switch ($modx->event->name) {
     case 'OnTempFormPrerender':
         $field = 'modx-template-content';
         $modxTags = true;
-
-        switch (true) {
-            case $modx->getOption('twiggy_class'):
-                $mimeType = 'text/x-twig';
-                break;
-            case $modx->getOption('pdotools_fenom_parser'):
-                $mimeType = 'text/x-smarty';
-                break;
-            default:
-                $mimeType = 'text/html';
-                break;
-        }
-
+        $mimeType = $html_elements_mime;
         break;
     case 'OnChunkFormPrerender':
         $field = 'modx-chunk-snippet';
@@ -74,22 +78,9 @@ switch ($modx->event->name) {
             $extension = pathinfo($modx->controller->chunk->getSourceFile(), PATHINFO_EXTENSION);
             $mimeType = isset($extensionMap[$extension]) ? $extensionMap[$extension] : 'text/plain';
         } else {
-            $mimeType = 'text/html';
+            $mimeType = $html_elements_mime;
         }
         $modxTags = true;
-
-        switch (true) {
-            case $modx->getOption('twiggy_class'):
-                $mimeType = 'text/x-twig';
-                break;
-            case $modx->getOption('pdotools_fenom_default'):
-                $mimeType = 'text/x-smarty';
-                break;
-            default:
-                $mimeType = 'text/html';
-                break;
-        }
-
         break;
     case 'OnPluginFormPrerender':
         $field = 'modx-plugin-plugincode';
@@ -114,14 +105,7 @@ switch ($modx->event->name) {
         $field = 'ta';
         $mimeType = $modx->getObject('modContentType', $modx->controller->resourceArray['content_type'])->get('mime_type');
 
-        switch (true) {
-            case $mimeType == 'text/html' && $modx->getOption('twiggy_class'):
-                $mimeType = 'text/x-twig';
-                break;
-            case $mimeType == 'text/html' && $modx->getOption('pdotools_fenom_parser'):
-                $mimeType = 'text/x-smarty';
-                break;
-        }
+        if($mimeType == 'text/html')$mimeType = $html_elements_mime;
 
         if ($modx->getOption('use_editor')){
             $richText = $modx->controller->resourceArray['richtext'];

--- a/core/components/ace/lexicon/de/default.inc.php
+++ b/core/components/ace/lexicon/de/default.inc.php
@@ -43,3 +43,5 @@ $_lang['setting_ace.snippets'] = 'Snippets';
 $_lang['setting_ace.snippets_desc'] = 'Code snippets expanded by “Tab”. Snippet example:<br /><br /><pre>\nsnippet getr\n	[!getResources? parents=`${1}`${2}]]\n</pre></br>You can insert “Tab” character by pressing Alt + 09';
 $_lang['setting_ace.height'] = 'Edit area height';
 $_lang['setting_ace.height_desc'] = 'Editor height in pixel unit. If left blank, a defaul height will be used.';
+$_lang['setting_ace.html_elements_mime'] = 'MIME-Typ für HTML-Elemente';
+$_lang['setting_ace.html_elements_mime_desc'] = 'Dieser Typ wird vom Editor für HTML-Elemente verwendet - Vorlagen, Chunks und Ressourcen mit HTML-Typ. Wenn nicht angegeben, wird der Standardtyp verwendet';

--- a/core/components/ace/lexicon/en/default.inc.php
+++ b/core/components/ace/lexicon/en/default.inc.php
@@ -43,3 +43,5 @@ $_lang['setting_ace.snippets'] = 'Snippets';
 $_lang['setting_ace.snippets_desc'] = 'Code snippets you can expand by pressing “Tab” key. Snippet example:<br /><br /><pre>\nsnippet getr\n	[!getResources? parents=`${1}`${2}]]\n</pre></br>You can insert “Tab” character by pressing Alt + 09';
 $_lang['setting_ace.height'] = 'Edit area height';
 $_lang['setting_ace.height_desc'] = 'Editor height in pixel unit. If left blank, a defaul height will be used.';
+$_lang['setting_ace.html_elements_mime'] = 'MIME-type for html elements';
+$_lang['setting_ace.html_elements_mime_desc'] = 'This type will be used by the editor for html elements - templates, chunks and resources with html type. If not specified, the default type will be used';

--- a/core/components/ace/lexicon/nl/default.inc.php
+++ b/core/components/ace/lexicon/nl/default.inc.php
@@ -40,3 +40,5 @@ $_lang['setting_ace.snippets'] = 'Snippets';
 $_lang['setting_ace.snippets_desc'] = 'Code snippets you can expand by pressing “Tab” key. Snippet example:<br /><br /><pre>\nsnippet getr\n	[!getResources? parents=`${1}`${2}]]\n</pre></br>You can insert “Tab” character by pressing Alt + 09';
 $_lang['setting_ace.height'] = 'Edit area height';
 $_lang['setting_ace.height_desc'] = 'Editor height in pixel unit. If left blank, a defaul height will be used.';
+$_lang['setting_ace.html_elements_mime'] = 'MIME-type voor html-elementen';
+$_lang['setting_ace.html_elements_mime_desc'] = 'Dit type wordt door de editor gebruikt voor html-elementen - sjablonen, chunks en bronnen met html-type. Als dit niet wordt opgegeven, wordt het standaardtype gebruikt';

--- a/core/components/ace/lexicon/ru/default.inc.php
+++ b/core/components/ace/lexicon/ru/default.inc.php
@@ -43,3 +43,5 @@ $_lang['setting_ace.snippets'] = 'Сниппеты';
 $_lang['setting_ace.snippets_desc'] = 'Сниппеты, разворачиваемые по клавише «Tab». Пример сниппета:<br /><br /><pre>\nsnippet getr\n	[!getResources? parents=`${1}`${2}]]\n</pre></br>Знак табуляции можно вставить используя клавиши Alt + 09';
 $_lang['setting_ace.height'] = 'Высота области редактирования';
 $_lang['setting_ace.height_desc'] = 'Высота редактора в пикселах. Если значение не указано, редактор будет иметь высоту по умолчанию.';
+$_lang['setting_ace.html_elements_mime'] = 'MIME-type для html элементов';
+$_lang['setting_ace.html_elements_mime_desc'] = 'Этот тип будет использован редактором для html элементов - шаблонов, чанков и ресурсов с типом html. Если не указан будет использован тип по умолчанию';


### PR DESCRIPTION
- Add option ace.html_elements_mime to force use this mime on templates, chunks and html resources
- Simplify logic to detect mime for templates, chunks and html resources
- Now static chunks get mime from file extension. Previously, this logic was ignored.
- Now static chunks may get mime from extension from its name:
  chunk.css - text/css, chunk.tpl - text/x-smarty, chunk.json - application/json etc.