### PR TITLE
fix: prevent undefined property warning in MODX 3

### DIFF
--- a/core/components/ace/elements/plugins/ace.plugin.php
+++ b/core/components/ace/elements/plugins/ace.plugin.php
@@ -103,7 +103,7 @@ switch ($modx->event->name) {
         $modxTags = $extension == 'tpl';
         break;
     case 'OnDocFormPrerender':
-        if (!$modx->controller->resourceArray) {
+        if (!$modx->controller || !isset($modx->controller->resourceArray)) {
             return;
         }
         $field = 'ta';


### PR DESCRIPTION
Hi, 

i found that in MODX 3, the `resourceArray` property of the controller can be undefined during the `OnDocFormPrerender` event in certain contexts. This leads to PHP warnings like "Accessing property on non-object" or "Undefined property".
This PR adds a safety check for both the controller and the resourceArray property to prevent these warnings.

Thanks!