### PR TITLE
fix(ace): fullscreen editor stacking and insets for MODX 3

### DIFF
--- a/assets/components/ace/modx.texteditor.js
+++ b/assets/components/ace/modx.texteditor.js
@@ -314,7 +314,7 @@ MODx.ux.Ace = Ext.extend(Ext.ux.Ace, {
 
         if (!MODx.ux.Ace.initialized) {
             var style = "\
-                .ace_maximized {position: fixed; border: none; top: 0; left: 0; right: 0; bottom: 0; width: auto !important; height: auto !important; margin: 0; z-index: 12000}\
+                .ace_maximized {position: fixed; border: none; top: 60px; left: 70px; right: 3px; bottom: 3px; width: auto !important; height: auto !important; margin: 0; z-index: 12000}\
                 .ace_maximizer {position: absolute; width: 16px; height: 16px; top: 3px; right: 3px; opacity: 0.7; z-index: 10; cursor: pointer; background: url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAMAAAAoLQ9TAAABgFBMVEVmrBxkqxpjqhlkqxprryFnrB1kqxtkqxp6uzJiqRhZow9kqxpmrBxlrBtnrBxjqhlmrBxjqhptsSNkqhplqxt4tyxkqhlmrB1mrBx5uzJmrBxorR9orR5nrB1kqhlorR14uS5mrRxhqBhmrR1aoxBlqxt3titusiRlqxpiqRd4ty1rrh9hqBdjqxp3tSpaow9mrR15ujBorh5lrBxapRFmrBxkqhpjqhp5uzBhqRdnrB1rsCJlrBt6vDNorh93tipmqxxhqRhapBFbpRJnrR1mrB14uC1usiVnrB1apRFhqReq1VmLxUGv5Gyt3GOs22Cm0FKn2FyUzUyRykev4WmUz1CUy0mw5G6RzEmr11xusSOSy0iOxkKPx0Or2V6CwTuo3GGUz0+Sy0mu5W6Ry0mq1lptsCORy0iNx0OAvDOo2V5/vDOCwDmPxkOOy0mj0lWl1lqu4Gap1Viv4mms2l+s3WSPx0SKwDtusiWCwTqQxUGSyUaRykiAvDSp2l+Qx0QdWpRIAAAAS3RSTlMAAAAa4gAAlfAZMRLhuQCV1ZXwGgDwlQCy8MzY2swS2PDqEdUisvDwABn64hEA8CLh+tq5MeoAAPAZ4eKy+tr6uREiMdXq8PDqIhHgP7bQAAAA4ElEQVR42mOw5uBw52cAA351CwUWBttk30p9iIBKTmGcFgNHeEKwlBIfAwOrjmxNQaQoQ0V8TVa9PDMDg7B0RF1MdhSDGJdLfWqVqS6Ta5BfvYAzO1Arp0xVOS8bo3FGtAwnxDBuHhsRBgYNVR5uBihgZAOTTDA+AxMjiDSDCYhzW0kAtTBKGMiJgwUs7cJ8eBkZHfISjTSBXDEu5RT/akVzJo/Q4mgBE3aGisr0OqjDkupyM9MYJEMCY6UcQU73ki3LL1JjMCwtqfWEmO5U6x1gz8Ci4CYkCBEQFBLV0wYAXu4m8P20SwoAAAAASUVORK5CYII=)}\
                 .ace_maximizer:hover {opacity: 1}\
             ";

--- a/core/components/ace/documents/changelog.txt
+++ b/core/components/ace/documents/changelog.txt
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Fullscreen Ace over the whole manager (MODX 3): right-hand panels and other chrome no longer stay on top. The editor node is moved to `document.body` while maximized and uses a higher `z-index`, fixing stacking limits inside `#modx-content` that core PR [modxcms/revolution#16778](https://github.com/modxcms/revolution/pull/16778) does not address for extras ([#18](https://github.com/modx-pro/modx-ace/issues/18)).
+- Fullscreen `.ace_maximized` insets (`top: 60px`, `left: 70px`, `right/bottom: 3px`) so the manager top bar, left tree, and resource/form header stay visible on MODX 3.1+ (see [community report](https://community.modx.com/t/3-1-0-issue-with-ace-editor-fullscreen/8267) and [workaround note](https://community.modx.com/t/3-1-0-issue-with-ace-editor-fullscreen/8267/5)).
 - In-editor PHP syntax check: false `Syntax error, unexpected '?'` (and similar) for valid PHP 7+ code such as null coalescing `??`. Bundled `worker-php.js` updated to [ace-builds](https://www.npmjs.com/package/ace-builds) **1.37.5** (`T_COALESCE` and related tokens).
 
 ## [1.9.8] - 2026-03-05


### PR DESCRIPTION
Fix Ace fullscreen mode in MODX 3 manager so the editor paints above sibling panels and respects manager chrome insets.

In MODX 3, fullscreen Ace stayed inside `#modx-content` with `z-index: 100`. Stacking contexts there let right-hand panels (resource TVs, etc.) render on top of the maximized editor. Core PR modxcms/revolution#16778 does not cover this for extras. While maximized, the editor node is reparented to `document.body` with `z-index: 12000`, then restored on exit and in `onDestroy`.

On MODX 3.1+ the manager layout also changed: edge-to-edge fullscreen hid the top bar, left tree, and resource header. `.ace_maximized` now uses insets (`top: 60px`, `left: 70px`, `right/bottom: 3px`) so those chrome elements stay visible, matching community workarounds for 3.1.0.

Raising z-index alone inside the original parent was considered but rejected: sibling panels still win because of stacking context boundaries. Leaving fullscreen edge-to-edge was rejected because it breaks the 3.1+ manager layout.

Fixes modx-pro/modx-ace#18