### PR TITLE
fix(ace): save correct content on Ctrl+S in fullscreen

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Интеграция [Ace](https://ace.c9.io/) (редактор кода) в **MODX Revolution** (2.x и 3.x): подсветка синтаксиса, автодополнение, темы, TV-поле и плагин для менеджера.
 
-**Версия пакета:** 1.9.9 (см. `_build/build.config.php` и `core/components/ace/documents/changelog.txt`)
+**Версия пакета:** 1.9.10 (см. `_build/build.config.php` и `core/components/ace/documents/changelog.txt`)
 
 ## Возможности
 

--- a/_build/build.config.php
+++ b/_build/build.config.php
@@ -6,7 +6,7 @@
 
 define('PKG_NAME', 'Ace');
 define('PKG_NAMESPACE', 'ace');
-define('PKG_VERSION', '1.9.9');
+define('PKG_VERSION', '1.9.10');
 define('PKG_RELEASE', 'pl');
 define('PKG_AUTO_INSTALL', true);
 

--- a/assets/components/ace/modx.texteditor.js
+++ b/assets/components/ace/modx.texteditor.js
@@ -186,6 +186,9 @@ Ext.ux.Ace = Ext.extend(Ext.form.TextField,  {
     },
 
     getValue : function (){
+        if (this.editor) {
+            this.valueHolder.value = this.editor.getSession().getValue();
+        }
         return this.valueHolder.value;
     },
 
@@ -426,6 +429,16 @@ MODx.ux.Ace = Ext.extend(Ext.ux.Ace, {
             parent: dom.parentNode,
             next: dom.nextSibling
         };
+        // Keep the named hidden input inside the form while the editor UI is on body.
+        // MODX Ctrl+S collects field values from the form DOM; reparenting would submit stale content (#25).
+        if (this.valueHolder && this.valueHolder.parentNode === dom) {
+            dom.removeChild(this.valueHolder);
+            if (this._aceFullscreenRestore.next && this._aceFullscreenRestore.next.parentNode === this._aceFullscreenRestore.parent) {
+                this._aceFullscreenRestore.parent.insertBefore(this.valueHolder, this._aceFullscreenRestore.next);
+            } else {
+                this._aceFullscreenRestore.parent.appendChild(this.valueHolder);
+            }
+        }
         document.body.appendChild(dom);
     },
 
@@ -436,6 +449,9 @@ MODx.ux.Ace = Ext.extend(Ext.ux.Ace, {
             return;
         }
         var dom = this.el.dom;
+        if (this.valueHolder && this.valueHolder.parentNode !== dom) {
+            dom.appendChild(this.valueHolder);
+        }
         if (r.next && r.next.parentNode === r.parent) {
             r.parent.insertBefore(dom, r.next);
         } else {
@@ -585,8 +601,23 @@ MODx.ux.Ace.replaceComponent = function(id, mimeType, modxTags) {
     textArea.el.dom.removeAttribute('name');
     textArea.el.setStyle('display', 'none');
     textEditor.render(textArea.el.dom.parentNode);
+    textArea.aceEditor = textEditor;
+    textArea.getValue = function() {
+        return textEditor.getValue();
+    };
+    textArea.setValue = function(value) {
+        textEditor.setValue(value);
+        return textArea;
+    };
     textArea.setSize = function(){textEditor.setSize.apply(textEditor, arguments)};
     textEditor.editor.on('change', function(e){textArea.fireEvent('change', e);});
+    if (!MODx.onSaveEditor) {
+        MODx.onSaveEditor = function(fld) {
+            if (fld && fld.aceEditor) {
+                fld.setValue(fld.aceEditor.getValue());
+            }
+        };
+    }
     textArea.on('destroy', function() {textEditor.destroy();});
     if (!modxTags)
         return;

--- a/core/components/ace/documents/changelog.txt
+++ b/core/components/ace/documents/changelog.txt
@@ -5,12 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.9.10] - 2026-07-07
+- Ctrl+S / Cmd+S in fullscreen on chunk/template/element forms: save showed success but wrote stale content because the hidden field left the form when the editor moved to `document.body`. The named input now stays in the form; `getValue()` syncs from Ace before submit; `MODx.onSaveEditor` syncs the original Ext field ([#25](https://github.com/modx-pro/modx-ace/issues/25)).
+
 ## [1.9.9] - 2026-03-29
 
 ### Fixed
 - Fullscreen Ace over the whole manager (MODX 3): right-hand panels and other chrome no longer stay on top. The editor node is moved to `document.body` while maximized and uses a higher `z-index`, fixing stacking limits inside `#modx-content` that core PR [modxcms/revolution#16778](https://github.com/modxcms/revolution/pull/16778) does not address for extras ([#18](https://github.com/modx-pro/modx-ace/issues/18)).
 - Fullscreen `.ace_maximized` insets (`top: 60px`, `left: 70px`, `right/bottom: 3px`) so the manager top bar, left tree, and resource/form header stay visible on MODX 3.1+ (see [community report](https://community.modx.com/t/3-1-0-issue-with-ace-editor-fullscreen/8267) and [workaround note](https://community.modx.com/t/3-1-0-issue-with-ace-editor-fullscreen/8267/5)).
-- Ctrl+S / Cmd+S in fullscreen on chunk/template/element forms: save showed success but wrote stale content because the hidden field left the form when the editor moved to `document.body`. The named input now stays in the form; `getValue()` syncs from Ace before submit; `MODx.onSaveEditor` syncs the original Ext field ([#25](https://github.com/modx-pro/modx-ace/issues/25)).
 - In-editor PHP syntax check: false `Syntax error, unexpected '?'` (and similar) for valid PHP 7+ code such as null coalescing `??`. Bundled `worker-php.js` updated to [ace-builds](https://www.npmjs.com/package/ace-builds) **1.37.5** (`T_COALESCE` and related tokens).
 
 ## [1.9.8] - 2026-03-05

--- a/core/components/ace/documents/changelog.txt
+++ b/core/components/ace/documents/changelog.txt
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Fullscreen Ace over the whole manager (MODX 3): right-hand panels and other chrome no longer stay on top. The editor node is moved to `document.body` while maximized and uses a higher `z-index`, fixing stacking limits inside `#modx-content` that core PR [modxcms/revolution#16778](https://github.com/modxcms/revolution/pull/16778) does not address for extras ([#18](https://github.com/modx-pro/modx-ace/issues/18)).
 - Fullscreen `.ace_maximized` insets (`top: 60px`, `left: 70px`, `right/bottom: 3px`) so the manager top bar, left tree, and resource/form header stay visible on MODX 3.1+ (see [community report](https://community.modx.com/t/3-1-0-issue-with-ace-editor-fullscreen/8267) and [workaround note](https://community.modx.com/t/3-1-0-issue-with-ace-editor-fullscreen/8267/5)).
+- Ctrl+S / Cmd+S in fullscreen on chunk/template/element forms: save showed success but wrote stale content because the hidden field left the form when the editor moved to `document.body`. The named input now stays in the form; `getValue()` syncs from Ace before submit; `MODx.onSaveEditor` syncs the original Ext field ([#25](https://github.com/modx-pro/modx-ace/issues/25)).
 - In-editor PHP syntax check: false `Syntax error, unexpected '?'` (and similar) for valid PHP 7+ code such as null coalescing `??`. Bundled `worker-php.js` updated to [ace-builds](https://www.npmjs.com/package/ace-builds) **1.37.5** (`T_COALESCE` and related tokens).
 
 ## [1.9.8] - 2026-03-05


### PR DESCRIPTION
Fix Ctrl+S / Cmd+S in fullscreen Ace on chunk, template, and other element forms so the saved content matches what the user edited.

After the fullscreen stacking fix (#18), the editor DOM moves to `document.body` while maximized. The hidden input that carries the field value moved with it, outside the MODX form. Ctrl+S still triggered save and showed success, but `getForm().getValues()` read the original hidden textarea with stale content.

While fullscreen, the named hidden input now stays in the form. `getValue()` syncs from the Ace session immediately before submit. `replaceComponent` delegates `getValue`/`setValue` on the original Ext field to Ace and registers `MODx.onSaveEditor` for `cleanupEditor` before submit.

Considered forwarding Ctrl+S to the save button only, but that would not fix stale values on button save if the form path already ran. Keeping the value holder in the form addresses the root cause.

Fixes modx-pro/modx-ace#25