### PR TITLE
fix(ace): skip resource Ace when another RTE is configured

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Интеграция [Ace](https://ace.c9.io/) (редактор кода) в **MODX Revolution** (2.x и 3.x): подсветка синтаксиса, автодополнение, темы, TV-поле и плагин для менеджера.
 
-**Версия пакета:** 1.9.10 (см. `_build/build.config.php` и `core/components/ace/documents/changelog.txt`)
+**Версия пакета:** 1.9.11 (см. `_build/build.config.php` и `core/components/ace/documents/changelog.txt`)
 
 ## Возможности
 

--- a/_build/build.config.php
+++ b/_build/build.config.php
@@ -6,7 +6,7 @@
 
 define('PKG_NAME', 'Ace');
 define('PKG_NAMESPACE', 'ace');
-define('PKG_VERSION', '1.9.10');
+define('PKG_VERSION', '1.9.11');
 define('PKG_RELEASE', 'pl');
 define('PKG_AUTO_INSTALL', true);
 

--- a/core/components/ace/documents/changelog.txt
+++ b/core/components/ace/documents/changelog.txt
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.9.11] - 2026-07-27
+
+### Fixed
+- Resource content form: Ace no longer replaces `#ta` when another RTE is configured (`which_editor` ≠ Ace). With `use_editor=Yes` and e.g. TinyMCE, non-richtext resources keep a plain textarea instead of Ace ([#30](https://github.com/modx-pro/modx-ace/issues/30)).
+- Resource content form: `use_editor` is read from the current context override when available, not only the global system setting ([#35](https://github.com/modx-pro/modx-ace/issues/35)).
+
 ## [1.9.10] - 2026-07-07
 - Ctrl+S / Cmd+S in fullscreen on chunk/template/element forms: save showed success but wrote stale content because the hidden field left the form when the editor moved to `document.body`. The named input now stays in the form; `getValue()` syncs from Ace before submit; `MODx.onSaveEditor` syncs the original Ext field ([#25](https://github.com/modx-pro/modx-ace/issues/25)).
 

--- a/core/components/ace/elements/plugins/ace.plugin.php
+++ b/core/components/ace/elements/plugins/ace.plugin.php
@@ -26,6 +26,22 @@ $corePath = $modx->getOption('ace.core_path', null, $modx->getOption('core_path'
 $ace = $modx->getService('ace', 'Ace', $corePath . 'model/ace/');
 $ace->initialize();
 
+if (!function_exists('aceGetEffectiveUseEditor')) {
+    function aceGetEffectiveUseEditor($modx) {
+        if ($modx->controller && !empty($modx->controller->context)) {
+            return (bool) $modx->controller->context->getOption('use_editor', $modx->getOption('use_editor'));
+        }
+        return (bool) $modx->getOption('use_editor');
+    }
+}
+
+if (!function_exists('aceIsNonAceRichTextEditor')) {
+    function aceIsNonAceRichTextEditor($modx) {
+        $whichEditor = trim((string) $modx->getOption('which_editor', ''));
+        return $whichEditor !== '' && strcasecmp($whichEditor, 'Ace') !== 0;
+    }
+}
+
 $extensionMap = array(
     'tpl'   => 'text/x-smarty',
     'htm'   => 'text/html',
@@ -63,6 +79,7 @@ if (!$html_elements_mime) {
 
 // Defines wether we should highlight modx tags
 $modxTags = false;
+$useEditor = null;
 switch ($modx->event->name) {
     case 'OnSnipFormPrerender':
         $field = 'modx-snippet-snippet';
@@ -103,9 +120,12 @@ switch ($modx->event->name) {
         $modxTags = $extension == 'tpl';
         break;
     case 'OnDocFormPrerender':
+        // Resource content: respect per-context use_editor (#35) and which_editor (#30).
+        // When another RTE is configured, do not replace #ta — MODX.loadRTE or plain textarea handles it.
         if (!$modx->controller || empty($modx->controller->resourceArray)) {
             return;
         }
+        $useEditor = aceGetEffectiveUseEditor($modx);
         $field = 'ta';
         $mimeType = $modx->getObject('modContentType', $modx->controller->resourceArray['content_type'])->get('mime_type');
 
@@ -113,10 +133,12 @@ switch ($modx->event->name) {
             $mimeType = $html_elements_mime;
         }
 
-        if ($modx->getOption('use_editor')) {
+        if ($useEditor) {
             $richText = $modx->controller->resourceArray['richtext'];
             $classKey = $modx->controller->resourceArray['class_key'];
             if ($richText || in_array($classKey, array('modStaticResource', 'modSymLink', 'modWebLink', 'modXMLRPCResource'))) {
+                $field = false;
+            } elseif (aceIsNonAceRichTextEditor($modx)) {
                 $field = false;
             }
         }
@@ -135,7 +157,7 @@ if (!empty($field)) {
     $script .= "MODx.ux.Ace.replaceComponent('$field', '$mimeType', $modxTags);";
 }
 
-if ($modx->event->name == 'OnDocFormPrerender' && !$modx->getOption('use_editor')) {
+if ($modx->event->name == 'OnDocFormPrerender' && $useEditor === false) {
     $script .= "MODx.ux.Ace.replaceTextAreas(Ext.query('.modx-richtext'));";
 }
 


### PR DESCRIPTION
## Summary
- Ace no longer replaces `#ta` on resource forms when `which_editor` is set to another RTE (e.g. TinyMCE)
- `use_editor` on resource forms respects per-context overrides

Fixes #30
Fixes #35

## Test plan
- [ ] TinyMCE + richtext=1: content uses TinyMCE, Ace not on `#ta`
- [ ] TinyMCE + richtext=0: plain textarea, Ace not initialized
- [ ] use_editor=No: Ace on `#ta` (regression)
- [ ] Context override use_editor=No: Ace on resource; use_editor=Yes + TinyMCE: no Ace
- [ ] Chunks/templates still use Ace via `which_element_editor`