### PR TITLE
fix(ace): guard onDestroy when editor was never initialized

### DIFF
--- a/assets/components/ace/modx.texteditor.js
+++ b/assets/components/ace/modx.texteditor.js
@@ -112,7 +112,10 @@ Ext.ux.Ace = Ext.extend(Ext.form.TextField,  {
     },
 
     onDestroy : function(){
-        this.editor.destroy();
+        if (this.editor) {
+            this.editor.destroy();
+            this.editor = null;
+        }
         Ext.ux.Ace.superclass.onDestroy.call(this);
     },
 
@@ -468,7 +471,7 @@ MODx.ux.Ace = Ext.extend(Ext.ux.Ace, {
     },
 
     onDestroy : function() {
-        if (this.isFullscreen) {
+        if (this.isFullscreen && this.el) {
             this.el.removeClass('ace_maximized');
             this.restoreAceFromFullscreenBody();
             this.isFullscreen = false;

--- a/core/components/ace/documents/changelog.txt
+++ b/core/components/ace/documents/changelog.txt
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Ctrl+S / Cmd+S in fullscreen on chunk/template/element forms: save showed success but wrote stale content because the hidden field left the form when the editor moved to `document.body`. The named input now stays in the form; `getValue()` syncs from Ace before submit; `MODx.onSaveEditor` syncs the original Ext field ([#25](https://github.com/modx-pro/modx-ace/issues/25)).
 - Resource content form: Ace no longer replaces `#ta` when another RTE is configured (`which_editor` ≠ Ace). With `use_editor=Yes` and e.g. TinyMCE, non-richtext resources keep a plain textarea instead of Ace ([#30](https://github.com/modx-pro/modx-ace/issues/30)).
 - Resource content form: `use_editor` is read from the current context override when available, not only the global system setting ([#35](https://github.com/modx-pro/modx-ace/issues/35)).
+- `onDestroy` no longer throws when Ace was never initialized (destroy before `onRender` or partial Ext component) ([#32](https://github.com/modx-pro/modx-ace/issues/32)).
 
 ## [1.9.9] - 2026-03-29
 


### PR DESCRIPTION
## Summary
- `Ext.ux.Ace.onDestroy` checks `this.editor` before calling `destroy()`
- `MODx.ux.Ace.onDestroy` guards fullscreen cleanup when `this.el` is missing

Fixes #32

## Test plan
- [ ] Create/destroy multiple Ace fields in a custom MODX panel — no console errors
- [ ] Normal Ace field destroy still releases the editor (no leak)