### PR TITLE
fix(ace): SCSS comments when MODX tag mode is off

### DIFF
--- a/core/components/ace/documents/changelog.txt
+++ b/core/components/ace/documents/changelog.txt
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Resource content form: Ace no longer replaces `#ta` when another RTE is configured (`which_editor` ≠ Ace). With `use_editor=Yes` and e.g. TinyMCE, non-richtext resources keep a plain textarea instead of Ace ([#30](https://github.com/modx-pro/modx-ace/issues/30)).
 - Resource content form: `use_editor` is read from the current context override when available, not only the global system setting ([#35](https://github.com/modx-pro/modx-ace/issues/35)).
 - `onDestroy` no longer throws when Ace was never initialized (destroy before `onRender` or partial Ext component) ([#32](https://github.com/modx-pro/modx-ace/issues/32)).
+- SCSS/CSS/static chunks: MODX tag mixed mode is enabled only for HTML-like mime types (`text/html`, Smarty, Twig), so `//` and `/* */` comments highlight correctly instead of HTML `<!-- -->` ([#31](https://github.com/modx-pro/modx-ace/issues/31)).
 
 ## [1.9.9] - 2026-03-29
 

--- a/core/components/ace/elements/plugins/ace.plugin.php
+++ b/core/components/ace/elements/plugins/ace.plugin.php
@@ -42,6 +42,20 @@ if (!function_exists('aceIsNonAceRichTextEditor')) {
     }
 }
 
+if (!function_exists('aceMimeSupportsModxTags')) {
+    function aceMimeSupportsModxTags($mimeType) {
+        if ($mimeType === '' || strpos($mimeType, '@FILE:') === 0) {
+            return false;
+        }
+        static $supported = array(
+            'text/html' => true,
+            'text/x-smarty' => true,
+            'text/x-twig' => true,
+        );
+        return !empty($supported[$mimeType]);
+    }
+}
+
 $extensionMap = array(
     'tpl'   => 'text/x-smarty',
     'htm'   => 'text/html',
@@ -87,8 +101,8 @@ switch ($modx->event->name) {
         break;
     case 'OnTempFormPrerender':
         $field = 'modx-template-content';
-        $modxTags = true;
         $mimeType = $html_elements_mime;
+        $modxTags = aceMimeSupportsModxTags($mimeType);
         break;
     case 'OnChunkFormPrerender':
         $field = 'modx-chunk-snippet';
@@ -101,7 +115,7 @@ switch ($modx->event->name) {
         } else {
             $mimeType = $html_elements_mime;
         }
-        $modxTags = true;
+        $modxTags = aceMimeSupportsModxTags($mimeType);
         break;
     case 'OnPluginFormPrerender':
         $field = 'modx-plugin-plugincode';
@@ -117,7 +131,7 @@ switch ($modx->event->name) {
         $mimeType = isset($extensionMap[$extension])
             ? $extensionMap[$extension]
             : ('@FILE:' . pathinfo($scriptProperties['file'], PATHINFO_BASENAME));
-        $modxTags = $extension == 'tpl';
+        $modxTags = aceMimeSupportsModxTags($mimeType);
         break;
     case 'OnDocFormPrerender':
         // Resource content: respect per-context use_editor (#35) and which_editor (#30).
@@ -142,7 +156,7 @@ switch ($modx->event->name) {
                 $field = false;
             }
         }
-        $modxTags = true;
+        $modxTags = aceMimeSupportsModxTags($mimeType);
         break;
     case 'OnTVInputRenderList':
         $modx->event->output($corePath . 'elements/tv/input/');


### PR DESCRIPTION
## Summary
- Add `aceMimeSupportsModxTags()` — true only for `text/html`, `text/x-smarty`, `text/x-twig`
- Chunks, templates, file edit, and resource forms use it instead of unconditional `modxTags=true`

Fixes #31

## Test plan
- [ ] Static SCSS chunk: `//` and `/* */` comments highlight as SCSS, not HTML
- [ ] HTML chunk/template: `[[*tv]]` MODX tag highlighting still works
- [ ] File edit `.scss` — SCSS comments; `.tpl` — MODX tags