### PR TITLE
fix(ace): Ace on resource cache overview tab

### DIFF
--- a/assets/components/ace/modx.texteditor.js
+++ b/assets/components/ace/modx.texteditor.js
@@ -589,16 +589,43 @@ MODx.ux.Ace = Ext.extend(Ext.ux.Ace, {
     }
 });
 
-MODx.ux.Ace.replaceComponent = function(id, mimeType, modxTags) {
+MODx.ux.Ace.replaceComponent = function(id, mimeType, modxTags, options) {
+    options = options || {};
     var textArea = Ext.getCmp(id);
     if (!textArea) {
         // Workaround for File Update panel (fix issue, caused by wrong event order)
         return setTimeout(function() {
-            var textArea = Ext.getCmp(id);
-            if (textArea)
-                MODx.ux.Ace.replaceComponent(id, mimeType, modxTags);
-        });
+            if (Ext.getCmp(id)) {
+                MODx.ux.Ace.replaceComponent(id, mimeType, modxTags, options);
+            }
+        }, 50);
     }
+    if (textArea.aceEditor) {
+        return;
+    }
+
+    var value = textArea.getValue();
+    if (!value && options.waitForValue !== false) {
+        var panel = Ext.getCmp('modx-panel-resource-data');
+        if (panel) {
+            var replaceWhenReady = function() {
+                MODx.ux.Ace.replaceComponent(id, mimeType, modxTags, {waitForValue: false});
+            };
+            panel.on('ready', replaceWhenReady, null, {single: true});
+            var pagetitleField = panel.getForm ? panel.getForm().findField('pagetitle') : null;
+            if (pagetitleField && pagetitleField.getValue()) {
+                replaceWhenReady();
+            }
+            return;
+        }
+        var attempts = options._attempts || 0;
+        if (attempts < 50) {
+            return setTimeout(function() {
+                MODx.ux.Ace.replaceComponent(id, mimeType, modxTags, Ext.applyIf({_attempts: attempts + 1}, options));
+            }, 100);
+        }
+    }
+
     var textEditor = MODx.load({
         xtype: 'modx-texteditor',
         enableKeyEvents: true,

--- a/core/components/ace/documents/changelog.txt
+++ b/core/components/ace/documents/changelog.txt
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Resource content form: `use_editor` is read from the current context override when available, not only the global system setting ([#35](https://github.com/modx-pro/modx-ace/issues/35)).
 - `onDestroy` no longer throws when Ace was never initialized (destroy before `onRender` or partial Ext component) ([#32](https://github.com/modx-pro/modx-ace/issues/32)).
 - SCSS/CSS/static chunks: MODX tag mixed mode is enabled only for HTML-like mime types (`text/html`, Smarty, Twig), so `//` and `/* */` comments highlight correctly instead of HTML `<!-- -->` ([#31](https://github.com/modx-pro/modx-ace/issues/31)).
+- Resource overview cache tab (`resource/data`): Ace initializes after cache buffer is loaded, so `modx-rdata-buffer` is not empty ([#28](https://github.com/modx-pro/modx-ace/issues/28)).
 
 ## [1.9.9] - 2026-03-29
 

--- a/core/components/ace/elements/plugins/ace.plugin.php
+++ b/core/components/ace/elements/plugins/ace.plugin.php
@@ -4,7 +4,7 @@
  *
  * Events: OnManagerPageBeforeRender, OnRichTextEditorRegister, OnSnipFormPrerender,
  * OnTempFormPrerender, OnChunkFormPrerender, OnPluginFormPrerender,
- * OnFileCreateFormPrerender, OnFileEditFormPrerender, OnDocFormPrerender
+ * OnFileCreateFormPrerender, OnFileEditFormPrerender, OnDocFormPrerender (incl. resource/data cache tab)
  *
  * @author Danil Kostin <danya.postfactum(at)gmail.com>
  *
@@ -53,6 +53,25 @@ if (!function_exists('aceMimeSupportsModxTags')) {
             'text/x-twig' => true,
         );
         return !empty($supported[$mimeType]);
+    }
+}
+
+if (!function_exists('aceIsResourceDataPage')) {
+    function aceIsResourceDataPage($modx) {
+        if (!$modx->controller) {
+            return false;
+        }
+        if (!empty($modx->controller->config['controller'])) {
+            $controller = strtolower(str_replace('\\', '/', $modx->controller->config['controller']));
+            if ($controller === 'resource/data') {
+                return true;
+            }
+        }
+        $action = $modx->getOption('action', $_REQUEST, '');
+        if ($action === '' && !empty($_REQUEST['a'])) {
+            $action = (string) $_REQUEST['a'];
+        }
+        return strtolower(str_replace('\\', '/', $action)) === 'resource/data';
     }
 }
 
@@ -156,6 +175,15 @@ switch ($modx->event->name) {
                 $field = false;
             }
         }
+        $modxTags = aceMimeSupportsModxTags($mimeType);
+        break;
+    case 'OnManagerPageBeforeRender':
+        // Resource overview cache tab: buffer loads asynchronously after panel render (#28).
+        if (!aceIsResourceDataPage($modx)) {
+            return;
+        }
+        $field = 'modx-rdata-buffer';
+        $mimeType = $html_elements_mime;
         $modxTags = aceMimeSupportsModxTags($mimeType);
         break;
     case 'OnTVInputRenderList':


### PR DESCRIPTION
## Summary
- Detect `resource/data` in `ace.plugin.php` and init Ace on `modx-rdata-buffer`
- `replaceComponent` waits for `modx-panel-resource-data` `ready` (or loaded form) before reading buffer value

Fixes #28

## Test plan
- [ ] Resource overview → Cache tab: Ace shows cached HTML with syntax highlighting
- [ ] Resource with no cache: Ace shows empty read-only field without errors
- [ ] File edit / chunk forms: existing replaceComponent retry still works