### PR TITLE
feat(ace): localStorage draft restore

### DIFF
--- a/_build/data/transport.settings.php
+++ b/_build/data/transport.settings.php
@@ -109,4 +109,13 @@ $settings['auto_close_tags']->fromArray(array(
         'area' => 'general'
     ),'',true,true);
 
+$settings['draft_restore']= $modx->newObject('modSystemSetting');
+$settings['draft_restore']->fromArray(array(
+        'key' => 'ace.draft_restore',
+        'xtype' => 'combo-boolean',
+        'value' => '0',
+        'namespace' => 'ace',
+        'area' => 'general'
+    ),'',true,true);
+
 return $settings;

--- a/assets/components/ace/modx.texteditor.js
+++ b/assets/components/ace/modx.texteditor.js
@@ -265,6 +265,133 @@ MODx.ux.Ace.isAutoCloseTagsEnabled = function() {
     return value == true || value === '1' || value === 1;
 };
 
+MODx.ux.Ace.isDraftRestoreEnabled = function() {
+    var value = MODx.config['ace.draft_restore'];
+    return value == true || value === '1' || value === 1;
+};
+
+MODx.ux.Ace.DraftManager = {
+    TTL_MS: 7 * 24 * 60 * 60 * 1000,
+    debounceMs: 500,
+
+    getStorageKey: function(field) {
+        var action = (MODx.request && MODx.request.a) ? MODx.request.a : 'manager';
+        var id = (MODx.request && MODx.request.id) ? MODx.request.id : '0';
+        var name = field.name || field.id || 'field';
+        return 'ace:draft:' + action + ':' + name + ':' + id;
+    },
+
+    readDraft: function(key) {
+        try {
+            var raw = localStorage.getItem(key);
+            if (!raw) {
+                return null;
+            }
+            var data = JSON.parse(raw);
+            if (!data || typeof data.value !== 'string') {
+                return null;
+            }
+            if (data.ts && (Date.now() - data.ts) > this.TTL_MS) {
+                localStorage.removeItem(key);
+                return null;
+            }
+            return data;
+        } catch (e) {
+            return null;
+        }
+    },
+
+    writeDraft: function(key, value) {
+        try {
+            localStorage.setItem(key, JSON.stringify({value: value, ts: Date.now()}));
+        } catch (e) {}
+    },
+
+    clearDraft: function(key) {
+        try {
+            localStorage.removeItem(key);
+        } catch (e) {}
+    },
+
+    bind: function(field, textEditor) {
+        if (!MODx.ux.Ace.isDraftRestoreEnabled() || field.readOnly === true) {
+            return;
+        }
+
+        var self = this;
+        var key = this.getStorageKey(field);
+        var initialValue = textEditor.getValue();
+        var draft = this.readDraft(key);
+
+        if (draft && draft.value !== initialValue) {
+            this.showRestoreBanner(textEditor, key, draft.value);
+        }
+
+        var saveTimer = null;
+        textEditor.editor.getSession().on('change', function() {
+            if (saveTimer) {
+                clearTimeout(saveTimer);
+            }
+            saveTimer = setTimeout(function() {
+                self.writeDraft(key, textEditor.getValue());
+            }, self.debounceMs);
+        });
+
+        var panel = field.findParentBy ? field.findParentBy(function(c) {
+            return c && c.getForm && c.getForm();
+        }) : null;
+        if (panel) {
+            panel.on('success', function() {
+                self.clearDraft(key);
+            });
+            var form = panel.getForm();
+            if (form) {
+                form.on('actioncomplete', function(f, action) {
+                    if (action && action.result && action.result.success) {
+                        self.clearDraft(key);
+                    }
+                });
+            }
+        }
+    },
+
+    showRestoreBanner: function(textEditor, key, draftValue) {
+        var banner = document.createElement('div');
+        banner.className = 'ace-draft-restore-banner';
+        banner.style.cssText = 'padding:6px 10px;background:#fff3cd;border:1px solid #ffc107;margin-bottom:4px;font-size:12px;';
+        banner.appendChild(document.createTextNode(_('ui_ace.draft_restore_prompt') + ' '));
+
+        var restoreLink = document.createElement('a');
+        restoreLink.href = '#';
+        restoreLink.className = 'ace-draft-restore-yes';
+        restoreLink.appendChild(document.createTextNode(_('ui_ace.draft_restore_yes')));
+        restoreLink.onclick = function(e) {
+            e.preventDefault();
+            textEditor.setValue(draftValue);
+            if (banner.parentNode) {
+                banner.parentNode.removeChild(banner);
+            }
+        };
+
+        var discardLink = document.createElement('a');
+        discardLink.href = '#';
+        discardLink.className = 'ace-draft-restore-no';
+        discardLink.appendChild(document.createTextNode(_('ui_ace.draft_restore_discard')));
+        discardLink.onclick = function(e) {
+            e.preventDefault();
+            MODx.ux.Ace.DraftManager.clearDraft(key);
+            if (banner.parentNode) {
+                banner.parentNode.removeChild(banner);
+            }
+        };
+
+        banner.appendChild(restoreLink);
+        banner.appendChild(document.createTextNode(' | '));
+        banner.appendChild(discardLink);
+        textEditor.el.dom.parentNode.insertBefore(banner, textEditor.el.dom);
+    }
+};
+
 MODx.ux.Ace = Ext.extend(Ext.ux.Ace, {
 
     mimeType : 'text/plain',
@@ -659,6 +786,7 @@ MODx.ux.Ace.replaceComponent = function(id, mimeType, modxTags, options) {
         };
     }
     textArea.on('destroy', function() {textEditor.destroy();});
+    MODx.ux.Ace.DraftManager.bind(textArea, textEditor);
     if (!modxTags)
         return;
     var dropTarget = MODx.load({
@@ -692,6 +820,7 @@ MODx.ux.Ace.replaceTextAreas = function(textAreas, mimeType) {
 
         editor.render(textArea.parentNode);
         editor.editor.on('change', function(e){ MODx.fireResourceFormChange() });
+        MODx.ux.Ace.DraftManager.bind({name: textArea.name, id: textArea.id, readOnly: textArea.readOnly}, editor);
     });
 };
 
@@ -721,6 +850,7 @@ MODx.ux.Ace.replaceTextArea = function(id, config) {
 
     editor.render(textArea.parentNode);
     editor.editor.on('change', function(e){ MODx.fireResourceFormChange() });
+    MODx.ux.Ace.DraftManager.bind({name: textArea.name, id: textArea.id, readOnly: textArea.readOnly}, editor);
     new IntersectionObserver(function(){
         editor.editor.resize(true);
         var tabs = Ext.get('modx-tv-tabs');

--- a/core/components/ace/documents/changelog.txt
+++ b/core/components/ace/documents/changelog.txt
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - Default MODX Tab snippets (`getr`, `pdoResources`, `chunk`, `[[*tv]]`, etc.) installed into `ace.snippets` on fresh install/upgrade when the setting is empty ([#36](https://github.com/modx-pro/modx-ace/issues/36)).
+- System setting `ace.draft_restore` to save editor drafts in browser localStorage and restore after accidental reload ([#33](https://github.com/modx-pro/modx-ace/issues/33)).
 - System setting `ace.auto_close_tags` to disable automatic closing of HTML tags, brackets, and MODX tag pairs ([#29](https://github.com/modx-pro/modx-ace/issues/29)).
 
 ### Fixed

--- a/core/components/ace/lexicon/de/default.inc.php
+++ b/core/components/ace/lexicon/de/default.inc.php
@@ -22,3 +22,6 @@ $_lang['ui_ace.replace'] = 'Ersetzen';
 $_lang['ui_ace.replace_all'] = 'Alle';
 $_lang['ui_ace.replace_with'] = 'Ersetzen durch';
 $_lang['ui_ace.whole_word'] = 'Ganze W&ouml;rter';
+$_lang['ui_ace.draft_restore_prompt'] = 'Für dieses Feld wurde ein nicht gespeicherter Entwurf gefunden.';
+$_lang['ui_ace.draft_restore_yes'] = 'Entwurf wiederherstellen';
+$_lang['ui_ace.draft_restore_discard'] = 'Verwerfen';

--- a/core/components/ace/lexicon/de/setting.inc.php
+++ b/core/components/ace/lexicon/de/setting.inc.php
@@ -32,3 +32,5 @@ $_lang['setting_ace.html_elements_mime'] = 'MIME-Typ für HTML-Elemente';
 $_lang['setting_ace.html_elements_mime_desc'] = 'Dieser Typ wird vom Editor für HTML-Elemente verwendet - Vorlagen, Chunks und Ressourcen mit HTML-Typ. Wenn nicht angegeben, wird der Standardtyp verwendet';
 $_lang['setting_ace.auto_close_tags'] = 'Tags und Klammern automatisch schließen';
 $_lang['setting_ace.auto_close_tags_desc'] = 'Schließende Klammern, Anführungszeichen und HTML/MODX-Tags beim Tippen automatisch einfügen.';
+$_lang['setting_ace.draft_restore'] = 'Entwürfe wiederherstellen';
+$_lang['setting_ace.draft_restore_desc'] = 'Editor-Inhalt im Browser localStorage speichern und nach versehentlichem Neuladen wieder anbieten (7 Tage TTL).';

--- a/core/components/ace/lexicon/en/default.inc.php
+++ b/core/components/ace/lexicon/en/default.inc.php
@@ -22,3 +22,6 @@ $_lang['ui_ace.replace'] = 'Replace';
 $_lang['ui_ace.replace_all'] = 'All';
 $_lang['ui_ace.replace_with'] = 'Replace with';
 $_lang['ui_ace.whole_word'] = 'Whole words';
+$_lang['ui_ace.draft_restore_prompt'] = 'An unsaved draft was found for this field.';
+$_lang['ui_ace.draft_restore_yes'] = 'Restore draft';
+$_lang['ui_ace.draft_restore_discard'] = 'Discard';

--- a/core/components/ace/lexicon/en/setting.inc.php
+++ b/core/components/ace/lexicon/en/setting.inc.php
@@ -32,3 +32,5 @@ $_lang['setting_ace.html_elements_mime'] = 'MIME-type for html elements';
 $_lang['setting_ace.html_elements_mime_desc'] = 'This type will be used by the editor for html elements - templates, chunks and resources with html type. If not specified, the default type will be used';
 $_lang['setting_ace.auto_close_tags'] = 'Auto-close tags and brackets';
 $_lang['setting_ace.auto_close_tags_desc'] = 'Automatically insert closing brackets, quotes, and HTML/MODX tags when typing.';
+$_lang['setting_ace.draft_restore'] = 'Restore unsaved drafts';
+$_lang['setting_ace.draft_restore_desc'] = 'Save editor content to browser localStorage while you edit and offer to restore it after an accidental reload (7-day TTL).';

--- a/core/components/ace/lexicon/nl/default.inc.php
+++ b/core/components/ace/lexicon/nl/default.inc.php
@@ -23,3 +23,6 @@ $_lang['ui_ace.replace'] = 'Vervangen';
 $_lang['ui_ace.replace_all'] = 'Alle';
 $_lang['ui_ace.replace_with'] = 'Vervang met';
 $_lang['ui_ace.whole_word'] = 'Hele woorden';
+$_lang['ui_ace.draft_restore_prompt'] = 'Er is een niet-opgeslagen concept voor dit veld gevonden.';
+$_lang['ui_ace.draft_restore_yes'] = 'Concept herstellen';
+$_lang['ui_ace.draft_restore_discard'] = 'Verwerpen';

--- a/core/components/ace/lexicon/nl/setting.inc.php
+++ b/core/components/ace/lexicon/nl/setting.inc.php
@@ -28,3 +28,5 @@ $_lang['setting_ace.html_elements_mime'] = 'MIME-type voor html-elementen';
 $_lang['setting_ace.html_elements_mime_desc'] = 'Dit type wordt door de editor gebruikt voor html-elementen - sjablonen, chunks en bronnen met html-type. Als dit niet wordt opgegeven, wordt het standaardtype gebruikt';
 $_lang['setting_ace.auto_close_tags'] = 'Tags en haakjes automatisch sluiten';
 $_lang['setting_ace.auto_close_tags_desc'] = 'Sluitende haakjes, aanhalingstekens en HTML/MODX-tags automatisch invoegen bij typen.';
+$_lang['setting_ace.draft_restore'] = 'Concepten herstellen';
+$_lang['setting_ace.draft_restore_desc'] = 'Editor-inhoud opslaan in browser localStorage en aanbieden na per ongeluk herladen (7 dagen TTL).';

--- a/core/components/ace/lexicon/ru/default.inc.php
+++ b/core/components/ace/lexicon/ru/default.inc.php
@@ -22,3 +22,6 @@ $_lang['ui_ace.replace'] = 'Заменить';
 $_lang['ui_ace.replace_all'] = 'Всё';
 $_lang['ui_ace.replace_with'] = 'Заменить на';
 $_lang['ui_ace.whole_word'] = 'Целые слова';
+$_lang['ui_ace.draft_restore_prompt'] = 'Для этого поля найден несохранённый черновик.';
+$_lang['ui_ace.draft_restore_yes'] = 'Восстановить';
+$_lang['ui_ace.draft_restore_discard'] = 'Отменить';

--- a/core/components/ace/lexicon/ru/setting.inc.php
+++ b/core/components/ace/lexicon/ru/setting.inc.php
@@ -32,3 +32,5 @@ $_lang['setting_ace.html_elements_mime'] = 'MIME-type для html элемент
 $_lang['setting_ace.html_elements_mime_desc'] = 'Этот тип будет использован редактором для html элементов - шаблонов, чанков и ресурсов с типом html. Если не указан будет использован тип по умолчанию';
 $_lang['setting_ace.auto_close_tags'] = 'Автозакрытие тегов и скобок';
 $_lang['setting_ace.auto_close_tags_desc'] = 'Автоматически вставлять закрывающие скобки, кавычки и HTML/MODX-теги при вводе.';
+$_lang['setting_ace.draft_restore'] = 'Восстановление черновиков';
+$_lang['setting_ace.draft_restore_desc'] = 'Сохранять текст редактора в localStorage и предлагать восстановление после случайной перезагрузки (срок хранения 7 дней).';


### PR DESCRIPTION
## Summary
- System setting `ace.draft_restore` (default off)
- Debounced localStorage saves with 7-day TTL
- Restore banner when draft differs from server value
- Draft cleared on successful form save

Fixes #33

## Test plan
- [ ] Enable setting, edit chunk, reload → restore banner appears
- [ ] Save form → draft cleared
- [ ] Read-only cache tab → no draft binding