### PR TITLE
feat(ace): CSS color preview (Pigments-style MVP)

### DIFF
--- a/_build/data/transport.settings.php
+++ b/_build/data/transport.settings.php
@@ -118,4 +118,13 @@ $settings['draft_restore']->fromArray(array(
         'area' => 'general'
     ),'',true,true);
 
+$settings['color_preview']= $modx->newObject('modSystemSetting');
+$settings['color_preview']->fromArray(array(
+        'key' => 'ace.color_preview',
+        'xtype' => 'combo-boolean',
+        'value' => '0',
+        'namespace' => 'ace',
+        'area' => 'general'
+    ),'',true,true);
+
 return $settings;

--- a/assets/components/ace/ace-color-preview.js
+++ b/assets/components/ace/ace-color-preview.js
@@ -1,0 +1,105 @@
+Ext.namespace('MODx.ux');
+
+MODx.ux.Ace.isColorPreviewEnabled = function() {
+    var value = MODx.config['ace.color_preview'];
+    return value == true || value === '1' || value === 1;
+};
+
+MODx.ux.Ace.supportsColorPreview = function(mimeType) {
+    if (!mimeType) {
+        return false;
+    }
+    return /css|scss|less|html|smarty|twig|svg/i.test(mimeType);
+};
+
+MODx.ux.Ace.ColorPreview = {
+    markerClassPrefix: 'ace-modx-color-marker-',
+    markerStyleEl: null,
+    markerSeq: 0,
+
+    init: function(editor, mimeType) {
+        if (!MODx.ux.Ace.isColorPreviewEnabled() || !MODx.ux.Ace.supportsColorPreview(mimeType)) {
+            return;
+        }
+
+        this.markerIds = [];
+        this.markerSeq = 0;
+        this.editor = editor;
+        var session = editor.getSession();
+        var refresh = this.debounce(this.refresh.bind(this), 150);
+        session.on('change', refresh);
+        editor.on('changeMode', refresh);
+        this.refresh();
+    },
+
+    refresh: function() {
+        var editor = this.editor;
+        if (!editor) {
+            return;
+        }
+
+        var session = editor.getSession();
+        var Range = ace.require('ace/range').Range;
+        var self = this;
+
+        this.markerIds.forEach(function(id) {
+            session.removeMarker(id);
+        });
+        this.markerIds = [];
+
+        if (!this.markerStyleEl) {
+            this.markerStyleEl = document.createElement('style');
+            this.markerStyleEl.id = 'ace-modx-color-preview-styles';
+            document.head.appendChild(this.markerStyleEl);
+        }
+
+        var rules = [];
+        var lines = session.doc.getAllLines();
+        var regex = /#([0-9a-fA-F]{3,8})\b|rgba?\(\s*[\d.]+\s*,\s*[\d.]+\s*,\s*[\d.]+(?:\s*,\s*[\d.]+)?\s*\)|hsla?\(\s*[\d.]+\s*,\s*[\d.]+%?\s*,\s*[\d.]+%?(?:\s*,\s*[\d.]+)?\s*\)/g;
+
+        for (var row = 0; row < lines.length; row++) {
+            var line = lines[row];
+            var match;
+            regex.lastIndex = 0;
+            while ((match = regex.exec(line)) !== null) {
+                var color = self.normalizeColor(match[0]);
+                if (!color) {
+                    continue;
+                }
+                var className = self.markerClassPrefix + (self.markerSeq++);
+                rules.push('.' + className + ' { background-color: ' + color + ' !important; opacity: 0.35; border-radius: 2px; }');
+                var markerId = session.addMarker(
+                    new Range(row, match.index, row, match.index + match[0].length),
+                    className,
+                    'text',
+                    false
+                );
+                self.markerIds.push(markerId);
+            }
+        }
+
+        this.markerStyleEl.textContent = rules.join('\n');
+    },
+
+    normalizeColor: function(value) {
+        if (/^#([0-9a-fA-F]{3}|[0-9a-fA-F]{6}|[0-9a-fA-F]{8})$/.test(value)) {
+            return value;
+        }
+        if (/^rgba?\(/i.test(value) || /^hsla?\(/i.test(value)) {
+            return value;
+        }
+        return null;
+    },
+
+    debounce: function(fn, ms) {
+        var timer;
+        return function() {
+            var args = arguments;
+            var ctx = this;
+            clearTimeout(timer);
+            timer = setTimeout(function() {
+                fn.apply(ctx, args);
+            }, ms);
+        };
+    }
+};

--- a/assets/components/ace/modx.texteditor.js
+++ b/assets/components/ace/modx.texteditor.js
@@ -455,6 +455,10 @@ MODx.ux.Ace = Ext.extend(Ext.ux.Ace, {
 
         this.setMimeType(this.mimeType);
 
+        if (MODx.ux.Ace.ColorPreview) {
+            MODx.ux.Ace.ColorPreview.init(this.editor, this.mimeType);
+        }
+
         if (!MODx.ux.Ace.initialized) {
             var style = "\
                 .ace_maximized {position: fixed; border: none; top: 60px; left: 70px; right: 3px; bottom: 3px; width: auto !important; height: auto !important; margin: 0; z-index: 12000}\

--- a/core/components/ace/documents/changelog.txt
+++ b/core/components/ace/documents/changelog.txt
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Default MODX Tab snippets (`getr`, `pdoResources`, `chunk`, `[[*tv]]`, etc.) installed into `ace.snippets` on fresh install/upgrade when the setting is empty ([#36](https://github.com/modx-pro/modx-ace/issues/36)).
 - System setting `ace.draft_restore` to save editor drafts in browser localStorage and restore after accidental reload ([#33](https://github.com/modx-pro/modx-ace/issues/33)).
+- System setting `ace.color_preview` to tint CSS color literals (#hex, rgb/hsl) in CSS/HTML modes ([#34](https://github.com/modx-pro/modx-ace/issues/34)).
 - System setting `ace.auto_close_tags` to disable automatic closing of HTML tags, brackets, and MODX tag pairs ([#29](https://github.com/modx-pro/modx-ace/issues/29)).
 
 ### Fixed

--- a/core/components/ace/lexicon/de/setting.inc.php
+++ b/core/components/ace/lexicon/de/setting.inc.php
@@ -34,3 +34,5 @@ $_lang['setting_ace.auto_close_tags'] = 'Tags und Klammern automatisch schließe
 $_lang['setting_ace.auto_close_tags_desc'] = 'Schließende Klammern, Anführungszeichen und HTML/MODX-Tags beim Tippen automatisch einfügen.';
 $_lang['setting_ace.draft_restore'] = 'Entwürfe wiederherstellen';
 $_lang['setting_ace.draft_restore_desc'] = 'Editor-Inhalt im Browser localStorage speichern und nach versehentlichem Neuladen wieder anbieten (7 Tage TTL).';
+$_lang['setting_ace.color_preview'] = 'CSS-Farbvorschau';
+$_lang['setting_ace.color_preview_desc'] = '#hex-, rgb()- und hsl()-Farbwerte in CSS/HTML-Modi mit getöntem Hintergrund markieren.';

--- a/core/components/ace/lexicon/en/setting.inc.php
+++ b/core/components/ace/lexicon/en/setting.inc.php
@@ -34,3 +34,5 @@ $_lang['setting_ace.auto_close_tags'] = 'Auto-close tags and brackets';
 $_lang['setting_ace.auto_close_tags_desc'] = 'Automatically insert closing brackets, quotes, and HTML/MODX tags when typing.';
 $_lang['setting_ace.draft_restore'] = 'Restore unsaved drafts';
 $_lang['setting_ace.draft_restore_desc'] = 'Save editor content to browser localStorage while you edit and offer to restore it after an accidental reload (7-day TTL).';
+$_lang['setting_ace.color_preview'] = 'CSS color preview';
+$_lang['setting_ace.color_preview_desc'] = 'Highlight #hex, rgb(), and hsl() color literals with a tinted background in CSS/HTML-related modes.';

--- a/core/components/ace/lexicon/nl/setting.inc.php
+++ b/core/components/ace/lexicon/nl/setting.inc.php
@@ -30,3 +30,5 @@ $_lang['setting_ace.auto_close_tags'] = 'Tags en haakjes automatisch sluiten';
 $_lang['setting_ace.auto_close_tags_desc'] = 'Sluitende haakjes, aanhalingstekens en HTML/MODX-tags automatisch invoegen bij typen.';
 $_lang['setting_ace.draft_restore'] = 'Concepten herstellen';
 $_lang['setting_ace.draft_restore_desc'] = 'Editor-inhoud opslaan in browser localStorage en aanbieden na per ongeluk herladen (7 dagen TTL).';
+$_lang['setting_ace.color_preview'] = 'CSS-kleurvoorbeeld';
+$_lang['setting_ace.color_preview_desc'] = 'Markeer #hex-, rgb()- en hsl()-kleuren met een getinte achtergrond in CSS/HTML-modi.';

--- a/core/components/ace/lexicon/ru/setting.inc.php
+++ b/core/components/ace/lexicon/ru/setting.inc.php
@@ -34,3 +34,5 @@ $_lang['setting_ace.auto_close_tags'] = 'Автозакрытие тегов и 
 $_lang['setting_ace.auto_close_tags_desc'] = 'Автоматически вставлять закрывающие скобки, кавычки и HTML/MODX-теги при вводе.';
 $_lang['setting_ace.draft_restore'] = 'Восстановление черновиков';
 $_lang['setting_ace.draft_restore_desc'] = 'Сохранять текст редактора в localStorage и предлагать восстановление после случайной перезагрузки (срок хранения 7 дней).';
+$_lang['setting_ace.color_preview'] = 'Предпросмотр CSS-цветов';
+$_lang['setting_ace.color_preview_desc'] = 'Подсвечивать литералы #hex, rgb() и hsl() полупрозрачным фоном в CSS/HTML-режимах.';

--- a/core/components/ace/model/ace/ace.class.php
+++ b/core/components/ace/model/ace/ace.class.php
@@ -41,6 +41,7 @@ class Ace {
             $this->modx->controller->addJavascript($this->config['assetsUrl'] . 'ace/ext-language_tools.js');
             $this->modx->controller->addJavascript($this->config['assetsUrl'] . 'ace/ext-keybinding_menu.js');
             $this->modx->controller->addJavascript($this->config['assetsUrl'] . 'ace/ext-emmet.js');
+            $this->modx->controller->addJavascript($this->config['assetsUrl'] . 'ace-color-preview.js');
             $this->modx->controller->addJavascript($this->config['assetsUrl'] . 'modx.texteditor.js');
 
             if (trim((string) $this->modx->getOption('ace.snippets', null, '')) === '') {


### PR DESCRIPTION
## Summary
- System setting `ace.color_preview` (default off)
- `ace-color-preview.js` tints matched color literals in CSS/HTML/SCSS modes

Fixes #34

## Test plan
- [ ] Enable setting, edit CSS chunk with `#fff` and `rgb(0,0,0)` → tinted highlight
- [ ] PHP snippet mode → no color preview