### PR TITLE
fix(ace): harden review findings for 1.9.10

### DIFF
--- a/assets/components/ace/ace-color-preview.js
+++ b/assets/components/ace/ace-color-preview.js
@@ -12,28 +12,84 @@ MODx.ux.Ace.supportsColorPreview = function(mimeType) {
     return /css|scss|less|html|smarty|twig|svg/i.test(mimeType);
 };
 
+/**
+ * Per-editor color preview instances (not a shared singleton).
+ * Avoids marker/state collisions when multiple Ace fields are on one page.
+ */
 MODx.ux.Ace.ColorPreview = {
-    markerClassPrefix: 'ace-modx-color-marker-',
-    markerStyleEl: null,
-    markerSeq: 0,
+    _instances: {},
+    _seq: 0,
+    MAX_SCAN_LINES: 2000,
 
     init: function(editor, mimeType) {
         if (!MODx.ux.Ace.isColorPreviewEnabled() || !MODx.ux.Ace.supportsColorPreview(mimeType)) {
-            return;
+            return null;
+        }
+        if (!editor) {
+            return null;
         }
 
-        this.markerIds = [];
-        this.markerSeq = 0;
-        this.editor = editor;
-        var session = editor.getSession();
-        var refresh = this.debounce(this.refresh.bind(this), 150);
-        session.on('change', refresh);
+        var id = editor.id || ('ace-color-' + (++this._seq));
+        if (!editor.id) {
+            editor.id = id;
+        }
+        this.destroy(editor);
+
+        var instance = {
+            editor: editor,
+            markerIds: [],
+            markerSeq: 0,
+            styleEl: null
+        };
+
+        instance.styleEl = document.createElement('style');
+        instance.styleEl.id = 'ace-modx-color-preview-' + id;
+        document.head.appendChild(instance.styleEl);
+
+        var refresh = this.debounce(function() {
+            MODx.ux.Ace.ColorPreview.refresh(instance);
+        }, 150);
+
+        instance._onChange = refresh;
+        editor.getSession().on('change', refresh);
         editor.on('changeMode', refresh);
-        this.refresh();
+        editor.on('changeSession', refresh);
+
+        this._instances[id] = instance;
+        this.refresh(instance);
+        return instance;
     },
 
-    refresh: function() {
-        var editor = this.editor;
+    destroy: function(editor) {
+        if (!editor) {
+            return;
+        }
+        var id = editor.id;
+        var instance = id ? this._instances[id] : null;
+        if (!instance) {
+            return;
+        }
+        var session = instance.editor.getSession();
+        instance.markerIds.forEach(function(markerId) {
+            session.removeMarker(markerId);
+        });
+        if (instance.styleEl && instance.styleEl.parentNode) {
+            instance.styleEl.parentNode.removeChild(instance.styleEl);
+        }
+        if (instance._onChange) {
+            try {
+                session.removeListener('change', instance._onChange);
+            } catch (e) {}
+            try {
+                instance.editor.removeListener('changeMode', instance._onChange);
+                instance.editor.removeListener('changeSession', instance._onChange);
+            } catch (e2) {}
+        }
+        delete this._instances[id];
+    },
+
+    refresh: function(instance) {
+        var editor = instance.editor;
         if (!editor) {
             return;
         }
@@ -42,22 +98,17 @@ MODx.ux.Ace.ColorPreview = {
         var Range = ace.require('ace/range').Range;
         var self = this;
 
-        this.markerIds.forEach(function(id) {
-            session.removeMarker(id);
+        instance.markerIds.forEach(function(markerId) {
+            session.removeMarker(markerId);
         });
-        this.markerIds = [];
+        instance.markerIds = [];
 
-        if (!this.markerStyleEl) {
-            this.markerStyleEl = document.createElement('style');
-            this.markerStyleEl.id = 'ace-modx-color-preview-styles';
-            document.head.appendChild(this.markerStyleEl);
-        }
-
-        var rules = [];
         var lines = session.doc.getAllLines();
-        var regex = /#([0-9a-fA-F]{3,8})\b|rgba?\(\s*[\d.]+\s*,\s*[\d.]+\s*,\s*[\d.]+(?:\s*,\s*[\d.]+)?\s*\)|hsla?\(\s*[\d.]+\s*,\s*[\d.]+%?\s*,\s*[\d.]+%?(?:\s*,\s*[\d.]+)?\s*\)/g;
+        var end = Math.min(lines.length, this.MAX_SCAN_LINES);
+        var rules = [];
+        var regex = /#([0-9a-fA-F]{3}|[0-9a-fA-F]{6}|[0-9a-fA-F]{8})\b|rgba?\(\s*(?:25[0-5]|2[0-4]\d|1?\d?\d)\s*,\s*(?:25[0-5]|2[0-4]\d|1?\d?\d)\s*,\s*(?:25[0-5]|2[0-4]\d|1?\d?\d)(?:\s*,\s*(?:0|1|0?\.\d+))?\s*\)|hsla?\(\s*-?\d+(?:\.\d+)?\s*,\s*\d+(?:\.\d+)?%\s*,\s*\d+(?:\.\d+)?%(?:\s*,\s*(?:0|1|0?\.\d+))?\s*\)/g;
 
-        for (var row = 0; row < lines.length; row++) {
+        for (var row = 0; row < end; row++) {
             var line = lines[row];
             var match;
             regex.lastIndex = 0;
@@ -66,19 +117,20 @@ MODx.ux.Ace.ColorPreview = {
                 if (!color) {
                     continue;
                 }
-                var className = self.markerClassPrefix + (self.markerSeq++);
-                rules.push('.' + className + ' { background-color: ' + color + ' !important; opacity: 0.35; border-radius: 2px; }');
-                var markerId = session.addMarker(
+                var className = 'ace-modx-color-marker-' + (instance.markerSeq++);
+                rules.push('.' + className + '{background-color:' + color + ' !important;opacity:0.35;border-radius:2px;}');
+                instance.markerIds.push(session.addMarker(
                     new Range(row, match.index, row, match.index + match[0].length),
                     className,
                     'text',
                     false
-                );
-                self.markerIds.push(markerId);
+                ));
             }
         }
 
-        this.markerStyleEl.textContent = rules.join('\n');
+        if (instance.styleEl) {
+            instance.styleEl.textContent = rules.join('\n');
+        }
     },
 
     normalizeColor: function(value) {

--- a/assets/components/ace/modx.texteditor.js
+++ b/assets/components/ace/modx.texteditor.js
@@ -39,6 +39,9 @@ Ext.ux.Ace = Ext.extend(Ext.form.TextField,  {
 
     initEvents : function(){
         Ext.ux.Ace.superclass.initEvents.call(this);
+        if (!this.editor) {
+            return;
+        }
         this.editor.on('focus', this.onFocus.bind(this));
         this.editor.on('blur', this.onBlur.bind(this));
     },
@@ -112,6 +115,9 @@ Ext.ux.Ace = Ext.extend(Ext.form.TextField,  {
     },
 
     onDestroy : function(){
+        if (MODx.ux.Ace.ColorPreview && this.editor) {
+            MODx.ux.Ace.ColorPreview.destroy(this.editor);
+        }
         if (this.editor) {
             this.editor.destroy();
             this.editor = null;
@@ -128,7 +134,9 @@ Ext.ux.Ace = Ext.extend(Ext.form.TextField,  {
     },
 
     onResize : function(){
-        this.editor.resize(true);
+        if (this.editor) {
+            this.editor.resize(true);
+        }
     },
 
     doAutoSize : function(e){
@@ -136,6 +144,9 @@ Ext.ux.Ace = Ext.extend(Ext.form.TextField,  {
     },
 
     autoSize: function(){
+        if (!this.editor) {
+            return;
+        }
         var linesCount = this.editor.getSession().getScreenLength();
         var lineHeight = this.editor.renderer.lineHeight;
         var scrollBar =  this.editor.renderer.scrollBar.getWidth();
@@ -185,7 +196,9 @@ Ext.ux.Ace = Ext.extend(Ext.form.TextField,  {
 
     setSize : function(width, height){
         Ext.ux.Ace.superclass.setSize.apply(this, arguments);
-        this.editor.resize(true);
+        if (this.editor) {
+            this.editor.resize(true);
+        }
     },
 
     getValue : function (){
@@ -256,141 +269,6 @@ Ext.ux.Ace = Ext.extend(Ext.form.TextField,  {
 Ext.reg('ace', Ext.ux.Ace);
 
 Ext.namespace('MODx.ux');
-
-MODx.ux.Ace.isAutoCloseTagsEnabled = function() {
-    var value = MODx.config['ace.auto_close_tags'];
-    if (value === undefined || value === null || value === '') {
-        return true;
-    }
-    return value == true || value === '1' || value === 1;
-};
-
-MODx.ux.Ace.isDraftRestoreEnabled = function() {
-    var value = MODx.config['ace.draft_restore'];
-    return value == true || value === '1' || value === 1;
-};
-
-MODx.ux.Ace.DraftManager = {
-    TTL_MS: 7 * 24 * 60 * 60 * 1000,
-    debounceMs: 500,
-
-    getStorageKey: function(field) {
-        var action = (MODx.request && MODx.request.a) ? MODx.request.a : 'manager';
-        var id = (MODx.request && MODx.request.id) ? MODx.request.id : '0';
-        var name = field.name || field.id || 'field';
-        return 'ace:draft:' + action + ':' + name + ':' + id;
-    },
-
-    readDraft: function(key) {
-        try {
-            var raw = localStorage.getItem(key);
-            if (!raw) {
-                return null;
-            }
-            var data = JSON.parse(raw);
-            if (!data || typeof data.value !== 'string') {
-                return null;
-            }
-            if (data.ts && (Date.now() - data.ts) > this.TTL_MS) {
-                localStorage.removeItem(key);
-                return null;
-            }
-            return data;
-        } catch (e) {
-            return null;
-        }
-    },
-
-    writeDraft: function(key, value) {
-        try {
-            localStorage.setItem(key, JSON.stringify({value: value, ts: Date.now()}));
-        } catch (e) {}
-    },
-
-    clearDraft: function(key) {
-        try {
-            localStorage.removeItem(key);
-        } catch (e) {}
-    },
-
-    bind: function(field, textEditor) {
-        if (!MODx.ux.Ace.isDraftRestoreEnabled() || field.readOnly === true) {
-            return;
-        }
-
-        var self = this;
-        var key = this.getStorageKey(field);
-        var initialValue = textEditor.getValue();
-        var draft = this.readDraft(key);
-
-        if (draft && draft.value !== initialValue) {
-            this.showRestoreBanner(textEditor, key, draft.value);
-        }
-
-        var saveTimer = null;
-        textEditor.editor.getSession().on('change', function() {
-            if (saveTimer) {
-                clearTimeout(saveTimer);
-            }
-            saveTimer = setTimeout(function() {
-                self.writeDraft(key, textEditor.getValue());
-            }, self.debounceMs);
-        });
-
-        var panel = field.findParentBy ? field.findParentBy(function(c) {
-            return c && c.getForm && c.getForm();
-        }) : null;
-        if (panel) {
-            panel.on('success', function() {
-                self.clearDraft(key);
-            });
-            var form = panel.getForm();
-            if (form) {
-                form.on('actioncomplete', function(f, action) {
-                    if (action && action.result && action.result.success) {
-                        self.clearDraft(key);
-                    }
-                });
-            }
-        }
-    },
-
-    showRestoreBanner: function(textEditor, key, draftValue) {
-        var banner = document.createElement('div');
-        banner.className = 'ace-draft-restore-banner';
-        banner.style.cssText = 'padding:6px 10px;background:#fff3cd;border:1px solid #ffc107;margin-bottom:4px;font-size:12px;';
-        banner.appendChild(document.createTextNode(_('ui_ace.draft_restore_prompt') + ' '));
-
-        var restoreLink = document.createElement('a');
-        restoreLink.href = '#';
-        restoreLink.className = 'ace-draft-restore-yes';
-        restoreLink.appendChild(document.createTextNode(_('ui_ace.draft_restore_yes')));
-        restoreLink.onclick = function(e) {
-            e.preventDefault();
-            textEditor.setValue(draftValue);
-            if (banner.parentNode) {
-                banner.parentNode.removeChild(banner);
-            }
-        };
-
-        var discardLink = document.createElement('a');
-        discardLink.href = '#';
-        discardLink.className = 'ace-draft-restore-no';
-        discardLink.appendChild(document.createTextNode(_('ui_ace.draft_restore_discard')));
-        discardLink.onclick = function(e) {
-            e.preventDefault();
-            MODx.ux.Ace.DraftManager.clearDraft(key);
-            if (banner.parentNode) {
-                banner.parentNode.removeChild(banner);
-            }
-        };
-
-        banner.appendChild(restoreLink);
-        banner.appendChild(document.createTextNode(' | '));
-        banner.appendChild(discardLink);
-        textEditor.el.dom.parentNode.insertBefore(banner, textEditor.el.dom);
-    }
-};
 
 MODx.ux.Ace = Ext.extend(Ext.ux.Ace, {
 
@@ -720,6 +598,180 @@ MODx.ux.Ace = Ext.extend(Ext.ux.Ace, {
     }
 });
 
+MODx.ux.Ace.isAutoCloseTagsEnabled = function() {
+    var value = MODx.config['ace.auto_close_tags'];
+    if (value === undefined || value === null || value === '') {
+        return true;
+    }
+    return value == true || value === '1' || value === 1;
+};
+
+MODx.ux.Ace.isDraftRestoreEnabled = function() {
+    var value = MODx.config['ace.draft_restore'];
+    return value == true || value === '1' || value === 1;
+};
+
+MODx.ux.Ace.DraftManager = {
+    TTL_MS: 7 * 24 * 60 * 60 * 1000,
+    debounceMs: 500,
+    _boundKeys: {},
+
+    getStorageKey: function(field) {
+        var action = (MODx.request && MODx.request.a) ? String(MODx.request.a) : 'manager';
+        var id = (MODx.request && MODx.request.id) ? String(MODx.request.id) : 'new';
+        var name = field.name || field.id || 'field';
+        if (!field.name && field.id) {
+            name = field.id;
+        }
+        return 'ace:draft:' + encodeURIComponent(action) + ':' + encodeURIComponent(name) + ':' + encodeURIComponent(id);
+    },
+
+    findFormPanel: function(field) {
+        if (field && field.findParentBy) {
+            return field.findParentBy(function(c) {
+                return c && c.getForm && c.getForm();
+            });
+        }
+        return Ext.getCmp('modx-panel-resource')
+            || Ext.getCmp('modx-panel-chunk')
+            || Ext.getCmp('modx-panel-template')
+            || Ext.getCmp('modx-panel-snippet')
+            || Ext.getCmp('modx-panel-plugin')
+            || Ext.getCmp('modx-panel-file')
+            || null;
+    },
+
+    readDraft: function(key) {
+        try {
+            var raw = localStorage.getItem(key);
+            if (!raw) {
+                return null;
+            }
+            var data = JSON.parse(raw);
+            if (!data || typeof data.value !== 'string') {
+                return null;
+            }
+            if (data.ts && (Date.now() - data.ts) > this.TTL_MS) {
+                localStorage.removeItem(key);
+                return null;
+            }
+            return data;
+        } catch (e) {
+            return null;
+        }
+    },
+
+    writeDraft: function(key, value) {
+        try {
+            localStorage.setItem(key, JSON.stringify({value: value, ts: Date.now()}));
+        } catch (e) {}
+    },
+
+    clearDraft: function(key) {
+        try {
+            localStorage.removeItem(key);
+        } catch (e) {}
+        delete this._boundKeys[key];
+    },
+
+    bindClearOnSave: function(key, field, textEditor) {
+        var self = this;
+        var clear = function() {
+            self.clearDraft(key);
+        };
+
+        if (textEditor) {
+            textEditor.aceDraftKey = key;
+        }
+
+        var panel = this.findFormPanel(field);
+        if (!panel) {
+            return;
+        }
+        panel.on('success', clear);
+        var form = panel.getForm && panel.getForm();
+        if (form) {
+            form.on('actioncomplete', function(f, action) {
+                if (action && action.result && action.result.success) {
+                    clear();
+                }
+            });
+        }
+    },
+
+    bind: function(field, textEditor) {
+        if (!MODx.ux.Ace.isDraftRestoreEnabled() || field.readOnly === true) {
+            return;
+        }
+        if (!textEditor || !textEditor.editor) {
+            return;
+        }
+
+        var self = this;
+        var key = this.getStorageKey(field);
+        if (this._boundKeys[key]) {
+            return;
+        }
+        this._boundKeys[key] = true;
+
+        var initialValue = textEditor.getValue();
+        var draft = this.readDraft(key);
+
+        // Offer restore only when draft differs and is non-empty (avoid noise for intentional clear).
+        if (draft && draft.value !== '' && draft.value !== initialValue) {
+            this.showRestoreBanner(textEditor, key, draft.value);
+        }
+
+        var saveTimer = null;
+        textEditor.editor.getSession().on('change', function() {
+            if (saveTimer) {
+                clearTimeout(saveTimer);
+            }
+            saveTimer = setTimeout(function() {
+                self.writeDraft(key, textEditor.getValue());
+            }, self.debounceMs);
+        });
+
+        this.bindClearOnSave(key, field, textEditor);
+    },
+
+    showRestoreBanner: function(textEditor, key, draftValue) {
+        var banner = document.createElement('div');
+        banner.className = 'ace-draft-restore-banner';
+        banner.style.cssText = 'padding:6px 10px;background:#fff3cd;border:1px solid #ffc107;margin-bottom:4px;font-size:12px;';
+        banner.appendChild(document.createTextNode(_('ui_ace.draft_restore_prompt') + ' '));
+
+        var restoreLink = document.createElement('a');
+        restoreLink.href = '#';
+        restoreLink.className = 'ace-draft-restore-yes';
+        restoreLink.appendChild(document.createTextNode(_('ui_ace.draft_restore_yes')));
+        restoreLink.onclick = function(e) {
+            e.preventDefault();
+            textEditor.setValue(draftValue);
+            if (banner.parentNode) {
+                banner.parentNode.removeChild(banner);
+            }
+        };
+
+        var discardLink = document.createElement('a');
+        discardLink.href = '#';
+        discardLink.className = 'ace-draft-restore-no';
+        discardLink.appendChild(document.createTextNode(_('ui_ace.draft_restore_discard')));
+        discardLink.onclick = function(e) {
+            e.preventDefault();
+            MODx.ux.Ace.DraftManager.clearDraft(key);
+            if (banner.parentNode) {
+                banner.parentNode.removeChild(banner);
+            }
+        };
+
+        banner.appendChild(restoreLink);
+        banner.appendChild(document.createTextNode(' | '));
+        banner.appendChild(discardLink);
+        textEditor.el.dom.parentNode.insertBefore(banner, textEditor.el.dom);
+    }
+};
+
 MODx.ux.Ace.replaceComponent = function(id, mimeType, modxTags, options) {
     options = options || {};
     var textArea = Ext.getCmp(id);
@@ -731,29 +783,39 @@ MODx.ux.Ace.replaceComponent = function(id, mimeType, modxTags, options) {
             }
         }, 50);
     }
-    if (textArea.aceEditor) {
+    if (textArea.aceEditor || textArea._aceReplacePending) {
         return;
     }
 
-    var value = textArea.getValue();
-    if (!value && options.waitForValue !== false) {
-        var panel = Ext.getCmp('modx-panel-resource-data');
-        if (panel) {
-            var replaceWhenReady = function() {
-                MODx.ux.Ace.replaceComponent(id, mimeType, modxTags, {waitForValue: false});
-            };
-            panel.on('ready', replaceWhenReady, null, {single: true});
-            var pagetitleField = panel.getForm ? panel.getForm().findField('pagetitle') : null;
-            if (pagetitleField && pagetitleField.getValue()) {
-                replaceWhenReady();
+    // Async cache buffer on resource overview only (#28). Do not delay empty new chunks/files.
+    if (id === 'modx-rdata-buffer' && options.waitForValue !== false) {
+        var value = textArea.getValue();
+        if (!value) {
+            var panel = Ext.getCmp('modx-panel-resource-data');
+            if (panel) {
+                textArea._aceReplacePending = true;
+                var replaceWhenReady = function() {
+                    textArea._aceReplacePending = false;
+                    if (textArea.aceEditor) {
+                        return;
+                    }
+                    MODx.ux.Ace.replaceComponent(id, mimeType, modxTags, {waitForValue: false});
+                };
+                if (panel.rendered && panel.getForm) {
+                    var pagetitleField = panel.getForm().findField('pagetitle');
+                    if (pagetitleField && pagetitleField.getValue()) {
+                        return replaceWhenReady();
+                    }
+                }
+                panel.on('ready', replaceWhenReady, null, {single: true});
+                return;
             }
-            return;
-        }
-        var attempts = options._attempts || 0;
-        if (attempts < 50) {
-            return setTimeout(function() {
-                MODx.ux.Ace.replaceComponent(id, mimeType, modxTags, Ext.applyIf({_attempts: attempts + 1}, options));
-            }, 100);
+            var attempts = options._attempts || 0;
+            if (attempts < 50) {
+                return setTimeout(function() {
+                    MODx.ux.Ace.replaceComponent(id, mimeType, modxTags, Ext.applyIf({_attempts: attempts + 1}, options));
+                }, 100);
+            }
         }
     }
 
@@ -773,6 +835,7 @@ MODx.ux.Ace.replaceComponent = function(id, mimeType, modxTags, options) {
     textArea.el.setStyle('display', 'none');
     textEditor.render(textArea.el.dom.parentNode);
     textArea.aceEditor = textEditor;
+    textArea._aceReplacePending = false;
     textArea.getValue = function() {
         return textEditor.getValue();
     };
@@ -786,6 +849,9 @@ MODx.ux.Ace.replaceComponent = function(id, mimeType, modxTags, options) {
         MODx.onSaveEditor = function(fld) {
             if (fld && fld.aceEditor) {
                 fld.setValue(fld.aceEditor.getValue());
+                if (fld.aceEditor.aceDraftKey) {
+                    MODx.ux.Ace.DraftManager.clearDraft(fld.aceEditor.aceDraftKey);
+                }
             }
         };
     }
@@ -809,11 +875,13 @@ MODx.ux.Ace.replaceComponent = function(id, mimeType, modxTags, options) {
 
 MODx.ux.Ace.replaceTextAreas = function(textAreas, mimeType) {
     textAreas.forEach(function(textArea){
+        var fieldName = textArea.name;
+        var fieldId = textArea.id;
         var editor = MODx.load({
             xtype: 'modx-texteditor',
             width: 'auto',
             height: parseInt(textArea.style.height) || 200,
-            name: textArea.name,
+            name: fieldName,
             value: textArea.value,
             mimeType: mimeType || 'text/html',
             modxTags: true
@@ -824,7 +892,7 @@ MODx.ux.Ace.replaceTextAreas = function(textAreas, mimeType) {
 
         editor.render(textArea.parentNode);
         editor.editor.on('change', function(e){ MODx.fireResourceFormChange() });
-        MODx.ux.Ace.DraftManager.bind({name: textArea.name, id: textArea.id, readOnly: textArea.readOnly}, editor);
+        MODx.ux.Ace.DraftManager.bind({name: fieldName, id: fieldId, readOnly: textArea.readOnly}, editor);
     });
 };
 
@@ -836,12 +904,14 @@ MODx.ux.Ace.replaceTextArea = function(id, config) {
         return undefined;
     }
     var textArea=textAreaElement.dom;
+    var fieldName = textArea.name;
+    var fieldId = textArea.id;
 
     Ext.applyIf(config,{
         xtype: 'modx-texteditor',
         width: 'auto',
         height: parseInt(textArea.style.height) || 200,
-        name: textArea.name,
+        name: fieldName,
         value: textArea.value,
         mimeType: 'text/html',
         modxTags: true
@@ -854,7 +924,7 @@ MODx.ux.Ace.replaceTextArea = function(id, config) {
 
     editor.render(textArea.parentNode);
     editor.editor.on('change', function(e){ MODx.fireResourceFormChange() });
-    MODx.ux.Ace.DraftManager.bind({name: textArea.name, id: textArea.id, readOnly: textArea.readOnly}, editor);
+    MODx.ux.Ace.DraftManager.bind({name: fieldName, id: fieldId, readOnly: textArea.readOnly}, editor);
     new IntersectionObserver(function(){
         editor.editor.resize(true);
         var tabs = Ext.get('modx-tv-tabs');

--- a/core/components/ace/documents/changelog.txt
+++ b/core/components/ace/documents/changelog.txt
@@ -20,6 +20,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `onDestroy` no longer throws when Ace was never initialized (destroy before `onRender` or partial Ext component) ([#32](https://github.com/modx-pro/modx-ace/issues/32)).
 - SCSS/CSS/static chunks: MODX tag mixed mode is enabled only for HTML-like mime types (`text/html`, Smarty, Twig), so `//` and `/* */` comments highlight correctly instead of HTML `<!-- -->` ([#31](https://github.com/modx-pro/modx-ace/issues/31)).
 - Resource overview cache tab (`resource/data`): Ace initializes after cache buffer is loaded, so `modx-rdata-buffer` is not empty ([#28](https://github.com/modx-pro/modx-ace/issues/28)).
+- Empty-field Ace init no longer waits up to 5s: async wait applies only to `modx-rdata-buffer` on the resource overview cache tab.
+- `which_editor` for resource forms also respects context overrides (aligned with `use_editor`).
+- Color preview is per-editor (no shared singleton), capped at 2000 lines, and cleaned up on destroy.
+- Draft restore: stable storage keys, non-empty draft banner only, clear on successful form save / `MODx.onSaveEditor`.
+- Guard `onResize` / `initEvents` / `autoSize` / `setSize` when Ace was never rendered.
+- Static Ace helpers (`DraftManager`, settings getters) attach after `Ext.extend` so they are not overwritten; `ace-color-preview.js` loads after `modx.texteditor.js`.
 
 ## [1.9.9] - 2026-03-29
 

--- a/core/components/ace/elements/plugins/ace.plugin.php
+++ b/core/components/ace/elements/plugins/ace.plugin.php
@@ -35,9 +35,18 @@ if (!function_exists('aceGetEffectiveUseEditor')) {
     }
 }
 
+if (!function_exists('aceGetEffectiveWhichEditor')) {
+    function aceGetEffectiveWhichEditor($modx) {
+        if ($modx->controller && !empty($modx->controller->context)) {
+            return trim((string) $modx->controller->context->getOption('which_editor', $modx->getOption('which_editor', '')));
+        }
+        return trim((string) $modx->getOption('which_editor', ''));
+    }
+}
+
 if (!function_exists('aceIsNonAceRichTextEditor')) {
     function aceIsNonAceRichTextEditor($modx) {
-        $whichEditor = trim((string) $modx->getOption('which_editor', ''));
+        $whichEditor = aceGetEffectiveWhichEditor($modx);
         return $whichEditor !== '' && strcasecmp($whichEditor, 'Ace') !== 0;
     }
 }

--- a/core/components/ace/model/ace/ace.class.php
+++ b/core/components/ace/model/ace/ace.class.php
@@ -41,8 +41,8 @@ class Ace {
             $this->modx->controller->addJavascript($this->config['assetsUrl'] . 'ace/ext-language_tools.js');
             $this->modx->controller->addJavascript($this->config['assetsUrl'] . 'ace/ext-keybinding_menu.js');
             $this->modx->controller->addJavascript($this->config['assetsUrl'] . 'ace/ext-emmet.js');
-            $this->modx->controller->addJavascript($this->config['assetsUrl'] . 'ace-color-preview.js');
             $this->modx->controller->addJavascript($this->config['assetsUrl'] . 'modx.texteditor.js');
+            $this->modx->controller->addJavascript($this->config['assetsUrl'] . 'ace-color-preview.js');
 
             if (trim((string) $this->modx->getOption('ace.snippets', null, '')) === '') {
                 $defaultSnippetsFile = $this->modx->getOption('assets_path') . 'components/ace/snippets/modx.default.snippets';


### PR DESCRIPTION
## Summary
Addresses code-review findings before 1.9.10 package release:

- Async empty-value wait only for `modx-rdata-buffer` (no 5s delay on new chunks)
- `_aceReplacePending` prevents double init race
- Color preview: per-editor instances, 2000-line cap, destroy cleanup
- Draft restore: stable keys, non-empty banner, save clearing, name captured before DOM clear
- `which_editor` reads context overrides
- Guards on `onResize` / `initEvents` / `autoSize` / `setSize`
- **Critical:** attach static helpers after `Ext.extend`; load `ace-color-preview.js` after `modx.texteditor.js`

## Test plan
- [ ] New empty chunk: Ace appears immediately
- [ ] Resource overview cache tab: Ace shows buffer after load
- [ ] Two CSS Ace fields + color_preview: both tint independently
- [ ] draft_restore: restore banner, save clears draft
- [ ] TinyMCE context override for which_editor still skips Ace on #ta