### PR TITLE
test: unit coverage for Ace helpers and JS utils

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,6 @@
 .idea
 .DS_Store
+/vendor/
+/node_modules/
+.phpunit.result.cache
+

--- a/README.md
+++ b/README.md
@@ -31,6 +31,19 @@
 
 Поиск корня MODX: `MODX_BASE_PATH` → `core/config/config.inc.php` вверх по каталогам → `core/model/modx/modx.class.php`.
 
+## Тесты
+
+Юнит-тесты покрывают хелперы плагина (RTE/mime/context) и чистую JS-логику (`ace-utils.js`).
+
+```bash
+composer install
+vendor/bin/phpunit
+
+npm test
+```
+
+Требования: PHP 7.4+, Node.js 18+.
+
 ## Структура репозитория
 
 | Путь | Назначение |
@@ -38,6 +51,7 @@
 | `core/components/ace/` | PHP-модель, плагин, процессоры автодополнения, лексиконы, TV input |
 | `assets/components/ace/` | JS (Ace, `modx.texteditor.js`), Emmet, `completions.php` |
 | `_build/` | Конфиг и скрипт сборки транспорта, резолвер установки |
+| `tests/` | PHPUnit (`tests/php`) и Node (`tests/js`) |
 
 ## Документация и история изменений
 

--- a/assets/components/ace/ace-color-preview.js
+++ b/assets/components/ace/ace-color-preview.js
@@ -1,15 +1,13 @@
 Ext.namespace('MODx.ux');
 
 MODx.ux.Ace.isColorPreviewEnabled = function() {
-    var value = MODx.config['ace.color_preview'];
-    return value == true || value === '1' || value === 1;
+    var utils = MODx.ux.Ace.Utils || MODx.ux.AceUtils;
+    return utils.parseBoolSetting(MODx.config['ace.color_preview'], false);
 };
 
 MODx.ux.Ace.supportsColorPreview = function(mimeType) {
-    if (!mimeType) {
-        return false;
-    }
-    return /css|scss|less|html|smarty|twig|svg/i.test(mimeType);
+    var utils = MODx.ux.Ace.Utils || MODx.ux.AceUtils;
+    return utils.mimeSupportsColorPreview(mimeType);
 };
 
 /**
@@ -96,7 +94,8 @@ MODx.ux.Ace.ColorPreview = {
 
         var session = editor.getSession();
         var Range = ace.require('ace/range').Range;
-        var self = this;
+        var utils = MODx.ux.Ace.Utils || MODx.ux.AceUtils;
+        var regex = new RegExp(utils.COLOR_LITERAL_REGEX.source, 'g');
 
         instance.markerIds.forEach(function(markerId) {
             session.removeMarker(markerId);
@@ -106,14 +105,13 @@ MODx.ux.Ace.ColorPreview = {
         var lines = session.doc.getAllLines();
         var end = Math.min(lines.length, this.MAX_SCAN_LINES);
         var rules = [];
-        var regex = /#([0-9a-fA-F]{3}|[0-9a-fA-F]{6}|[0-9a-fA-F]{8})\b|rgba?\(\s*(?:25[0-5]|2[0-4]\d|1?\d?\d)\s*,\s*(?:25[0-5]|2[0-4]\d|1?\d?\d)\s*,\s*(?:25[0-5]|2[0-4]\d|1?\d?\d)(?:\s*,\s*(?:0|1|0?\.\d+))?\s*\)|hsla?\(\s*-?\d+(?:\.\d+)?\s*,\s*\d+(?:\.\d+)?%\s*,\s*\d+(?:\.\d+)?%(?:\s*,\s*(?:0|1|0?\.\d+))?\s*\)/g;
 
         for (var row = 0; row < end; row++) {
             var line = lines[row];
             var match;
             regex.lastIndex = 0;
             while ((match = regex.exec(line)) !== null) {
-                var color = self.normalizeColor(match[0]);
+                var color = utils.normalizeCssColor(match[0]);
                 if (!color) {
                     continue;
                 }
@@ -134,13 +132,8 @@ MODx.ux.Ace.ColorPreview = {
     },
 
     normalizeColor: function(value) {
-        if (/^#([0-9a-fA-F]{3}|[0-9a-fA-F]{6}|[0-9a-fA-F]{8})$/.test(value)) {
-            return value;
-        }
-        if (/^rgba?\(/i.test(value) || /^hsla?\(/i.test(value)) {
-            return value;
-        }
-        return null;
+        var utils = MODx.ux.Ace.Utils || MODx.ux.AceUtils;
+        return utils.normalizeCssColor(value);
     },
 
     debounce: function(fn, ms) {

--- a/assets/components/ace/ace-utils.js
+++ b/assets/components/ace/ace-utils.js
@@ -1,0 +1,83 @@
+/**
+ * Pure Ace helpers shared by manager JS and Node unit tests.
+ * Browser: MODx.ux.AceUtils (survives Ext.extend) and MODx.ux.Ace.Utils when Ace exists
+ * Node: module.exports
+ */
+(function (root, factory) {
+    var utils = factory();
+    if (typeof module === 'object' && module.exports) {
+        module.exports = utils;
+    }
+    if (typeof Ext !== 'undefined') {
+        Ext.namespace('MODx.ux');
+        MODx.ux.AceUtils = utils;
+        if (MODx.ux.Ace) {
+            MODx.ux.Ace.Utils = utils;
+        }
+    } else if (root) {
+        root.AceUtils = utils;
+    }
+}(typeof globalThis !== 'undefined' ? globalThis : this, function () {
+    'use strict';
+
+    var COLOR_LITERAL_REGEX = /#([0-9a-fA-F]{3}|[0-9a-fA-F]{6}|[0-9a-fA-F]{8})\b|rgba?\(\s*(?:25[0-5]|2[0-4]\d|1?\d?\d)\s*,\s*(?:25[0-5]|2[0-4]\d|1?\d?\d)\s*,\s*(?:25[0-5]|2[0-4]\d|1?\d?\d)(?:\s*,\s*(?:0|1|0?\.\d+))?\s*\)|hsla?\(\s*-?\d+(?:\.\d+)?\s*,\s*\d+(?:\.\d+)?%\s*,\s*\d+(?:\.\d+)?%(?:\s*,\s*(?:0|1|0?\.\d+))?\s*\)/g;
+
+    function parseBoolSetting(value, defaultValue) {
+        if (value === undefined || value === null || value === '') {
+            return defaultValue === undefined ? false : !!defaultValue;
+        }
+        return value === true || value === '1' || value === 1;
+    }
+
+    function draftStorageKey(action, name, id) {
+        var a = action ? String(action) : 'manager';
+        var n = name ? String(name) : 'field';
+        var i = (id === undefined || id === null || id === '') ? 'new' : String(id);
+        return 'ace:draft:' + encodeURIComponent(a) + ':' + encodeURIComponent(n) + ':' + encodeURIComponent(i);
+    }
+
+    function shouldOfferDraftRestore(draftValue, initialValue) {
+        return typeof draftValue === 'string'
+            && draftValue !== ''
+            && draftValue !== initialValue;
+    }
+
+    function normalizeCssColor(value) {
+        if (!value || typeof value !== 'string') {
+            return null;
+        }
+        if (/^#([0-9a-fA-F]{3}|[0-9a-fA-F]{6}|[0-9a-fA-F]{8})$/.test(value)) {
+            return value;
+        }
+        if (/^rgba?\(/i.test(value) || /^hsla?\(/i.test(value)) {
+            COLOR_LITERAL_REGEX.lastIndex = 0;
+            var match = COLOR_LITERAL_REGEX.exec(value);
+            if (match && match[0] === value) {
+                return value;
+            }
+            return null;
+        }
+        return null;
+    }
+
+    function mimeSupportsColorPreview(mimeType) {
+        if (!mimeType) {
+            return false;
+        }
+        return /css|scss|less|html|smarty|twig|svg/i.test(mimeType);
+    }
+
+    function shouldWaitForAsyncBuffer(fieldId) {
+        return fieldId === 'modx-rdata-buffer';
+    }
+
+    return {
+        COLOR_LITERAL_REGEX: COLOR_LITERAL_REGEX,
+        parseBoolSetting: parseBoolSetting,
+        draftStorageKey: draftStorageKey,
+        shouldOfferDraftRestore: shouldOfferDraftRestore,
+        normalizeCssColor: normalizeCssColor,
+        mimeSupportsColorPreview: mimeSupportsColorPreview,
+        shouldWaitForAsyncBuffer: shouldWaitForAsyncBuffer
+    };
+}));

--- a/assets/components/ace/modx.texteditor.js
+++ b/assets/components/ace/modx.texteditor.js
@@ -598,17 +598,18 @@ MODx.ux.Ace = Ext.extend(Ext.ux.Ace, {
     }
 });
 
+if (MODx.ux.AceUtils) {
+    MODx.ux.Ace.Utils = MODx.ux.AceUtils;
+}
+
 MODx.ux.Ace.isAutoCloseTagsEnabled = function() {
-    var value = MODx.config['ace.auto_close_tags'];
-    if (value === undefined || value === null || value === '') {
-        return true;
-    }
-    return value == true || value === '1' || value === 1;
+    var utils = MODx.ux.Ace.Utils || MODx.ux.AceUtils;
+    return utils.parseBoolSetting(MODx.config['ace.auto_close_tags'], true);
 };
 
 MODx.ux.Ace.isDraftRestoreEnabled = function() {
-    var value = MODx.config['ace.draft_restore'];
-    return value == true || value === '1' || value === 1;
+    var utils = MODx.ux.Ace.Utils || MODx.ux.AceUtils;
+    return utils.parseBoolSetting(MODx.config['ace.draft_restore'], false);
 };
 
 MODx.ux.Ace.DraftManager = {
@@ -617,13 +618,14 @@ MODx.ux.Ace.DraftManager = {
     _boundKeys: {},
 
     getStorageKey: function(field) {
+        var utils = MODx.ux.Ace.Utils || MODx.ux.AceUtils;
         var action = (MODx.request && MODx.request.a) ? String(MODx.request.a) : 'manager';
         var id = (MODx.request && MODx.request.id) ? String(MODx.request.id) : 'new';
         var name = field.name || field.id || 'field';
         if (!field.name && field.id) {
             name = field.id;
         }
-        return 'ace:draft:' + encodeURIComponent(action) + ':' + encodeURIComponent(name) + ':' + encodeURIComponent(id);
+        return utils.draftStorageKey(action, name, id);
     },
 
     findFormPanel: function(field) {
@@ -718,7 +720,8 @@ MODx.ux.Ace.DraftManager = {
         var draft = this.readDraft(key);
 
         // Offer restore only when draft differs and is non-empty (avoid noise for intentional clear).
-        if (draft && draft.value !== '' && draft.value !== initialValue) {
+        var utils = MODx.ux.Ace.Utils || MODx.ux.AceUtils;
+        if (draft && utils.shouldOfferDraftRestore(draft.value, initialValue)) {
             this.showRestoreBanner(textEditor, key, draft.value);
         }
 
@@ -788,7 +791,8 @@ MODx.ux.Ace.replaceComponent = function(id, mimeType, modxTags, options) {
     }
 
     // Async cache buffer on resource overview only (#28). Do not delay empty new chunks/files.
-    if (id === 'modx-rdata-buffer' && options.waitForValue !== false) {
+    var utils = MODx.ux.Ace.Utils || MODx.ux.AceUtils;
+    if (utils.shouldWaitForAsyncBuffer(id) && options.waitForValue !== false) {
         var value = textArea.getValue();
         if (!value) {
             var panel = Ext.getCmp('modx-panel-resource-data');

--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,19 @@
+{
+    "name": "modx-pro/modx-ace",
+    "description": "Ace code editor for MODX Revolution",
+    "license": "GPL-2.0-or-later",
+    "require": {
+        "php": ">=7.4"
+    },
+    "require-dev": {
+        "phpunit/phpunit": "^9.6"
+    },
+    "autoload-dev": {
+        "psr-4": {
+            "Ace\\Tests\\": "tests/php/"
+        }
+    },
+    "scripts": {
+        "test": "phpunit"
+    }
+}

--- a/composer.lock
+++ b/composer.lock
@@ -1,0 +1,1800 @@
+{
+    "_readme": [
+        "This file locks the dependencies of your project to a known state",
+        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
+        "This file is @generated automatically"
+    ],
+    "content-hash": "012e6f4c669f189c823ea6899330b74a",
+    "packages": [],
+    "packages-dev": [
+        {
+            "name": "doctrine/instantiator",
+            "version": "2.1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/doctrine/instantiator.git",
+                "reference": "23da848e1a2308728fe5fdddabf4be17ff9720c7"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/doctrine/instantiator/zipball/23da848e1a2308728fe5fdddabf4be17ff9720c7",
+                "reference": "23da848e1a2308728fe5fdddabf4be17ff9720c7",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^8.4"
+            },
+            "require-dev": {
+                "doctrine/coding-standard": "^14",
+                "ext-pdo": "*",
+                "ext-phar": "*",
+                "phpbench/phpbench": "^1.2",
+                "phpstan/phpstan": "^2.1",
+                "phpstan/phpstan-phpunit": "^2.0",
+                "phpunit/phpunit": "^10.5.58"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Doctrine\\Instantiator\\": "src/Doctrine/Instantiator/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Marco Pivetta",
+                    "email": "ocramius@gmail.com",
+                    "homepage": "https://ocramius.github.io/"
+                }
+            ],
+            "description": "A small, lightweight utility to instantiate objects in PHP without invoking their constructors",
+            "homepage": "https://www.doctrine-project.org/projects/instantiator.html",
+            "keywords": [
+                "constructor",
+                "instantiate"
+            ],
+            "support": {
+                "issues": "https://github.com/doctrine/instantiator/issues",
+                "source": "https://github.com/doctrine/instantiator/tree/2.1.0"
+            },
+            "funding": [
+                {
+                    "url": "https://www.doctrine-project.org/sponsorship.html",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://www.patreon.com/phpdoctrine",
+                    "type": "patreon"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/doctrine%2Finstantiator",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-01-05T06:47:08+00:00"
+        },
+        {
+            "name": "myclabs/deep-copy",
+            "version": "1.13.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/myclabs/DeepCopy.git",
+                "reference": "07d290f0c47959fd5eed98c95ee5602db07e0b6a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/myclabs/DeepCopy/zipball/07d290f0c47959fd5eed98c95ee5602db07e0b6a",
+                "reference": "07d290f0c47959fd5eed98c95ee5602db07e0b6a",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.1 || ^8.0"
+            },
+            "conflict": {
+                "doctrine/collections": "<1.6.8",
+                "doctrine/common": "<2.13.3 || >=3 <3.2.2"
+            },
+            "require-dev": {
+                "doctrine/collections": "^1.6.8",
+                "doctrine/common": "^2.13.3 || ^3.2.2",
+                "phpspec/prophecy": "^1.10",
+                "phpunit/phpunit": "^7.5.20 || ^8.5.23 || ^9.5.13"
+            },
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "src/DeepCopy/deep_copy.php"
+                ],
+                "psr-4": {
+                    "DeepCopy\\": "src/DeepCopy/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "Create deep copies (clones) of your objects",
+            "keywords": [
+                "clone",
+                "copy",
+                "duplicate",
+                "object",
+                "object graph"
+            ],
+            "support": {
+                "issues": "https://github.com/myclabs/DeepCopy/issues",
+                "source": "https://github.com/myclabs/DeepCopy/tree/1.13.4"
+            },
+            "funding": [
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/myclabs/deep-copy",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2025-08-01T08:46:24+00:00"
+        },
+        {
+            "name": "nikic/php-parser",
+            "version": "v5.8.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/nikic/PHP-Parser.git",
+                "reference": "044a6a392ff8ad0d61f14370a5fbbd0a0107152f"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/044a6a392ff8ad0d61f14370a5fbbd0a0107152f",
+                "reference": "044a6a392ff8ad0d61f14370a5fbbd0a0107152f",
+                "shasum": ""
+            },
+            "require": {
+                "ext-json": "*",
+                "ext-tokenizer": "*",
+                "php": ">=7.4"
+            },
+            "require-dev": {
+                "ircmaxell/php-yacc": "^0.0.7",
+                "phpunit/phpunit": "^9.0"
+            },
+            "bin": [
+                "bin/php-parse"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "5.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "PhpParser\\": "lib/PhpParser"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Nikita Popov"
+                }
+            ],
+            "description": "A PHP parser written in PHP",
+            "keywords": [
+                "parser",
+                "php"
+            ],
+            "support": {
+                "issues": "https://github.com/nikic/PHP-Parser/issues",
+                "source": "https://github.com/nikic/PHP-Parser/tree/v5.8.0"
+            },
+            "time": "2026-07-04T14:30:18+00:00"
+        },
+        {
+            "name": "phar-io/manifest",
+            "version": "2.0.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phar-io/manifest.git",
+                "reference": "54750ef60c58e43759730615a392c31c80e23176"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phar-io/manifest/zipball/54750ef60c58e43759730615a392c31c80e23176",
+                "reference": "54750ef60c58e43759730615a392c31c80e23176",
+                "shasum": ""
+            },
+            "require": {
+                "ext-dom": "*",
+                "ext-libxml": "*",
+                "ext-phar": "*",
+                "ext-xmlwriter": "*",
+                "phar-io/version": "^3.0.1",
+                "php": "^7.2 || ^8.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Arne Blankerts",
+                    "email": "arne@blankerts.de",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Sebastian Heuer",
+                    "email": "sebastian@phpeople.de",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "Developer"
+                }
+            ],
+            "description": "Component for reading phar.io manifest information from a PHP Archive (PHAR)",
+            "support": {
+                "issues": "https://github.com/phar-io/manifest/issues",
+                "source": "https://github.com/phar-io/manifest/tree/2.0.4"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/theseer",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-03-03T12:33:53+00:00"
+        },
+        {
+            "name": "phar-io/version",
+            "version": "3.2.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phar-io/version.git",
+                "reference": "4f7fd7836c6f332bb2933569e566a0d6c4cbed74"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phar-io/version/zipball/4f7fd7836c6f332bb2933569e566a0d6c4cbed74",
+                "reference": "4f7fd7836c6f332bb2933569e566a0d6c4cbed74",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.2 || ^8.0"
+            },
+            "type": "library",
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Arne Blankerts",
+                    "email": "arne@blankerts.de",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Sebastian Heuer",
+                    "email": "sebastian@phpeople.de",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "Developer"
+                }
+            ],
+            "description": "Library for handling version information and constraints",
+            "support": {
+                "issues": "https://github.com/phar-io/version/issues",
+                "source": "https://github.com/phar-io/version/tree/3.2.1"
+            },
+            "time": "2022-02-21T01:04:05+00:00"
+        },
+        {
+            "name": "phpunit/php-code-coverage",
+            "version": "9.2.32",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/php-code-coverage.git",
+                "reference": "85402a822d1ecf1db1096959413d35e1c37cf1a5"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/85402a822d1ecf1db1096959413d35e1c37cf1a5",
+                "reference": "85402a822d1ecf1db1096959413d35e1c37cf1a5",
+                "shasum": ""
+            },
+            "require": {
+                "ext-dom": "*",
+                "ext-libxml": "*",
+                "ext-xmlwriter": "*",
+                "nikic/php-parser": "^4.19.1 || ^5.1.0",
+                "php": ">=7.3",
+                "phpunit/php-file-iterator": "^3.0.6",
+                "phpunit/php-text-template": "^2.0.4",
+                "sebastian/code-unit-reverse-lookup": "^2.0.3",
+                "sebastian/complexity": "^2.0.3",
+                "sebastian/environment": "^5.1.5",
+                "sebastian/lines-of-code": "^1.0.4",
+                "sebastian/version": "^3.0.2",
+                "theseer/tokenizer": "^1.2.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.6"
+            },
+            "suggest": {
+                "ext-pcov": "PHP extension that provides line coverage",
+                "ext-xdebug": "PHP extension that provides line coverage as well as branch and path coverage"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "9.2.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Library that provides collection, processing, and rendering functionality for PHP code coverage information.",
+            "homepage": "https://github.com/sebastianbergmann/php-code-coverage",
+            "keywords": [
+                "coverage",
+                "testing",
+                "xunit"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/php-code-coverage/issues",
+                "security": "https://github.com/sebastianbergmann/php-code-coverage/security/policy",
+                "source": "https://github.com/sebastianbergmann/php-code-coverage/tree/9.2.32"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-08-22T04:23:01+00:00"
+        },
+        {
+            "name": "phpunit/php-file-iterator",
+            "version": "3.0.6",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/php-file-iterator.git",
+                "reference": "cf1c2e7c203ac650e352f4cc675a7021e7d1b3cf"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-file-iterator/zipball/cf1c2e7c203ac650e352f4cc675a7021e7d1b3cf",
+                "reference": "cf1c2e7c203ac650e352f4cc675a7021e7d1b3cf",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "FilterIterator implementation that filters files based on a list of suffixes.",
+            "homepage": "https://github.com/sebastianbergmann/php-file-iterator/",
+            "keywords": [
+                "filesystem",
+                "iterator"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/php-file-iterator/issues",
+                "source": "https://github.com/sebastianbergmann/php-file-iterator/tree/3.0.6"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2021-12-02T12:48:52+00:00"
+        },
+        {
+            "name": "phpunit/php-invoker",
+            "version": "3.1.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/php-invoker.git",
+                "reference": "5a10147d0aaf65b58940a0b72f71c9ac0423cc67"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-invoker/zipball/5a10147d0aaf65b58940a0b72f71c9ac0423cc67",
+                "reference": "5a10147d0aaf65b58940a0b72f71c9ac0423cc67",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "ext-pcntl": "*",
+                "phpunit/phpunit": "^9.3"
+            },
+            "suggest": {
+                "ext-pcntl": "*"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.1-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Invoke callables with a timeout",
+            "homepage": "https://github.com/sebastianbergmann/php-invoker/",
+            "keywords": [
+                "process"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/php-invoker/issues",
+                "source": "https://github.com/sebastianbergmann/php-invoker/tree/3.1.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-09-28T05:58:55+00:00"
+        },
+        {
+            "name": "phpunit/php-text-template",
+            "version": "2.0.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/php-text-template.git",
+                "reference": "5da5f67fc95621df9ff4c4e5a84d6a8a2acf7c28"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-text-template/zipball/5da5f67fc95621df9ff4c4e5a84d6a8a2acf7c28",
+                "reference": "5da5f67fc95621df9ff4c4e5a84d6a8a2acf7c28",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Simple template engine.",
+            "homepage": "https://github.com/sebastianbergmann/php-text-template/",
+            "keywords": [
+                "template"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/php-text-template/issues",
+                "source": "https://github.com/sebastianbergmann/php-text-template/tree/2.0.4"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-10-26T05:33:50+00:00"
+        },
+        {
+            "name": "phpunit/php-timer",
+            "version": "5.0.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/php-timer.git",
+                "reference": "5a63ce20ed1b5bf577850e2c4e87f4aa902afbd2"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-timer/zipball/5a63ce20ed1b5bf577850e2c4e87f4aa902afbd2",
+                "reference": "5a63ce20ed1b5bf577850e2c4e87f4aa902afbd2",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "5.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Utility class for timing",
+            "homepage": "https://github.com/sebastianbergmann/php-timer/",
+            "keywords": [
+                "timer"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/php-timer/issues",
+                "source": "https://github.com/sebastianbergmann/php-timer/tree/5.0.3"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-10-26T13:16:10+00:00"
+        },
+        {
+            "name": "phpunit/phpunit",
+            "version": "9.6.35",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/phpunit.git",
+                "reference": "0edba2f3a0c48df3553cb9b640810b30df60302b"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/0edba2f3a0c48df3553cb9b640810b30df60302b",
+                "reference": "0edba2f3a0c48df3553cb9b640810b30df60302b",
+                "shasum": ""
+            },
+            "require": {
+                "doctrine/instantiator": "^1.5.0 || ^2",
+                "ext-dom": "*",
+                "ext-filter": "*",
+                "ext-json": "*",
+                "ext-libxml": "*",
+                "ext-mbstring": "*",
+                "ext-xmlwriter": "*",
+                "myclabs/deep-copy": "^1.13.4",
+                "phar-io/manifest": "^2.0.4",
+                "phar-io/version": "^3.2.1",
+                "php": ">=7.3",
+                "phpunit/php-code-coverage": "^9.2.32",
+                "phpunit/php-file-iterator": "^3.0.6",
+                "phpunit/php-invoker": "^3.1.1",
+                "phpunit/php-text-template": "^2.0.4",
+                "phpunit/php-timer": "^5.0.3",
+                "sebastian/cli-parser": "^1.0.2",
+                "sebastian/code-unit": "^1.0.8",
+                "sebastian/comparator": "^4.0.10",
+                "sebastian/diff": "^4.0.6",
+                "sebastian/environment": "^5.1.5",
+                "sebastian/exporter": "^4.0.8",
+                "sebastian/global-state": "^5.0.8",
+                "sebastian/object-enumerator": "^4.0.4",
+                "sebastian/resource-operations": "^3.0.4",
+                "sebastian/type": "^3.2.1",
+                "sebastian/version": "^3.0.2"
+            },
+            "suggest": {
+                "ext-soap": "To be able to generate mocks based on WSDL files",
+                "ext-xdebug": "PHP extension that provides line coverage as well as branch and path coverage"
+            },
+            "bin": [
+                "phpunit"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "9.6-dev"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "src/Framework/Assert/Functions.php"
+                ],
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "The PHP Unit Testing framework.",
+            "homepage": "https://phpunit.de/",
+            "keywords": [
+                "phpunit",
+                "testing",
+                "xunit"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/phpunit/issues",
+                "security": "https://github.com/sebastianbergmann/phpunit/security/policy",
+                "source": "https://github.com/sebastianbergmann/phpunit/tree/9.6.35"
+            },
+            "funding": [
+                {
+                    "url": "https://phpunit.de/sponsoring.html",
+                    "type": "other"
+                }
+            ],
+            "time": "2026-07-06T14:48:07+00:00"
+        },
+        {
+            "name": "sebastian/cli-parser",
+            "version": "1.0.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/cli-parser.git",
+                "reference": "2b56bea83a09de3ac06bb18b92f068e60cc6f50b"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/cli-parser/zipball/2b56bea83a09de3ac06bb18b92f068e60cc6f50b",
+                "reference": "2b56bea83a09de3ac06bb18b92f068e60cc6f50b",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Library for parsing CLI options",
+            "homepage": "https://github.com/sebastianbergmann/cli-parser",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/cli-parser/issues",
+                "source": "https://github.com/sebastianbergmann/cli-parser/tree/1.0.2"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-03-02T06:27:43+00:00"
+        },
+        {
+            "name": "sebastian/code-unit",
+            "version": "1.0.8",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/code-unit.git",
+                "reference": "1fc9f64c0927627ef78ba436c9b17d967e68e120"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/code-unit/zipball/1fc9f64c0927627ef78ba436c9b17d967e68e120",
+                "reference": "1fc9f64c0927627ef78ba436c9b17d967e68e120",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Collection of value objects that represent the PHP code units",
+            "homepage": "https://github.com/sebastianbergmann/code-unit",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/code-unit/issues",
+                "source": "https://github.com/sebastianbergmann/code-unit/tree/1.0.8"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-10-26T13:08:54+00:00"
+        },
+        {
+            "name": "sebastian/code-unit-reverse-lookup",
+            "version": "2.0.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/code-unit-reverse-lookup.git",
+                "reference": "ac91f01ccec49fb77bdc6fd1e548bc70f7faa3e5"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/code-unit-reverse-lookup/zipball/ac91f01ccec49fb77bdc6fd1e548bc70f7faa3e5",
+                "reference": "ac91f01ccec49fb77bdc6fd1e548bc70f7faa3e5",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Looks up which function or method a line of code belongs to",
+            "homepage": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/issues",
+                "source": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/tree/2.0.3"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-09-28T05:30:19+00:00"
+        },
+        {
+            "name": "sebastian/comparator",
+            "version": "4.0.10",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/comparator.git",
+                "reference": "e4df00b9b3571187db2831ae9aada2c6efbd715d"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/e4df00b9b3571187db2831ae9aada2c6efbd715d",
+                "reference": "e4df00b9b3571187db2831ae9aada2c6efbd715d",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3",
+                "sebastian/diff": "^4.0",
+                "sebastian/exporter": "^4.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "4.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                },
+                {
+                    "name": "Jeff Welch",
+                    "email": "whatthejeff@gmail.com"
+                },
+                {
+                    "name": "Volker Dusch",
+                    "email": "github@wallbash.com"
+                },
+                {
+                    "name": "Bernhard Schussek",
+                    "email": "bschussek@2bepublished.at"
+                }
+            ],
+            "description": "Provides the functionality to compare PHP values for equality",
+            "homepage": "https://github.com/sebastianbergmann/comparator",
+            "keywords": [
+                "comparator",
+                "compare",
+                "equality"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/comparator/issues",
+                "source": "https://github.com/sebastianbergmann/comparator/tree/4.0.10"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                },
+                {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/sebastian/comparator",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-01-24T09:22:56+00:00"
+        },
+        {
+            "name": "sebastian/complexity",
+            "version": "2.0.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/complexity.git",
+                "reference": "25f207c40d62b8b7aa32f5ab026c53561964053a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/complexity/zipball/25f207c40d62b8b7aa32f5ab026c53561964053a",
+                "reference": "25f207c40d62b8b7aa32f5ab026c53561964053a",
+                "shasum": ""
+            },
+            "require": {
+                "nikic/php-parser": "^4.18 || ^5.0",
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Library for calculating the complexity of PHP code units",
+            "homepage": "https://github.com/sebastianbergmann/complexity",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/complexity/issues",
+                "source": "https://github.com/sebastianbergmann/complexity/tree/2.0.3"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2023-12-22T06:19:30+00:00"
+        },
+        {
+            "name": "sebastian/diff",
+            "version": "4.0.6",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/diff.git",
+                "reference": "ba01945089c3a293b01ba9badc29ad55b106b0bc"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/diff/zipball/ba01945089c3a293b01ba9badc29ad55b106b0bc",
+                "reference": "ba01945089c3a293b01ba9badc29ad55b106b0bc",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.3",
+                "symfony/process": "^4.2 || ^5"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "4.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                },
+                {
+                    "name": "Kore Nordmann",
+                    "email": "mail@kore-nordmann.de"
+                }
+            ],
+            "description": "Diff implementation",
+            "homepage": "https://github.com/sebastianbergmann/diff",
+            "keywords": [
+                "diff",
+                "udiff",
+                "unidiff",
+                "unified diff"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/diff/issues",
+                "source": "https://github.com/sebastianbergmann/diff/tree/4.0.6"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-03-02T06:30:58+00:00"
+        },
+        {
+            "name": "sebastian/environment",
+            "version": "5.1.5",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/environment.git",
+                "reference": "830c43a844f1f8d5b7a1f6d6076b784454d8b7ed"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/environment/zipball/830c43a844f1f8d5b7a1f6d6076b784454d8b7ed",
+                "reference": "830c43a844f1f8d5b7a1f6d6076b784454d8b7ed",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.3"
+            },
+            "suggest": {
+                "ext-posix": "*"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "5.1-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Provides functionality to handle HHVM/PHP environments",
+            "homepage": "http://www.github.com/sebastianbergmann/environment",
+            "keywords": [
+                "Xdebug",
+                "environment",
+                "hhvm"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/environment/issues",
+                "source": "https://github.com/sebastianbergmann/environment/tree/5.1.5"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2023-02-03T06:03:51+00:00"
+        },
+        {
+            "name": "sebastian/exporter",
+            "version": "4.0.8",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/exporter.git",
+                "reference": "14c6ba52f95a36c3d27c835d65efc7123c446e8c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/exporter/zipball/14c6ba52f95a36c3d27c835d65efc7123c446e8c",
+                "reference": "14c6ba52f95a36c3d27c835d65efc7123c446e8c",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3",
+                "sebastian/recursion-context": "^4.0"
+            },
+            "require-dev": {
+                "ext-mbstring": "*",
+                "phpunit/phpunit": "^9.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "4.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                },
+                {
+                    "name": "Jeff Welch",
+                    "email": "whatthejeff@gmail.com"
+                },
+                {
+                    "name": "Volker Dusch",
+                    "email": "github@wallbash.com"
+                },
+                {
+                    "name": "Adam Harvey",
+                    "email": "aharvey@php.net"
+                },
+                {
+                    "name": "Bernhard Schussek",
+                    "email": "bschussek@gmail.com"
+                }
+            ],
+            "description": "Provides the functionality to export PHP variables for visualization",
+            "homepage": "https://www.github.com/sebastianbergmann/exporter",
+            "keywords": [
+                "export",
+                "exporter"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/exporter/issues",
+                "source": "https://github.com/sebastianbergmann/exporter/tree/4.0.8"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                },
+                {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/sebastian/exporter",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2025-09-24T06:03:27+00:00"
+        },
+        {
+            "name": "sebastian/global-state",
+            "version": "5.0.8",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/global-state.git",
+                "reference": "b6781316bdcd28260904e7cc18ec983d0d2ef4f6"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/global-state/zipball/b6781316bdcd28260904e7cc18ec983d0d2ef4f6",
+                "reference": "b6781316bdcd28260904e7cc18ec983d0d2ef4f6",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3",
+                "sebastian/object-reflector": "^2.0",
+                "sebastian/recursion-context": "^4.0"
+            },
+            "require-dev": {
+                "ext-dom": "*",
+                "phpunit/phpunit": "^9.3"
+            },
+            "suggest": {
+                "ext-uopz": "*"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "5.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Snapshotting of global state",
+            "homepage": "http://www.github.com/sebastianbergmann/global-state",
+            "keywords": [
+                "global state"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/global-state/issues",
+                "source": "https://github.com/sebastianbergmann/global-state/tree/5.0.8"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                },
+                {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/sebastian/global-state",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2025-08-10T07:10:35+00:00"
+        },
+        {
+            "name": "sebastian/lines-of-code",
+            "version": "1.0.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/lines-of-code.git",
+                "reference": "e1e4a170560925c26d424b6a03aed157e7dcc5c5"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/lines-of-code/zipball/e1e4a170560925c26d424b6a03aed157e7dcc5c5",
+                "reference": "e1e4a170560925c26d424b6a03aed157e7dcc5c5",
+                "shasum": ""
+            },
+            "require": {
+                "nikic/php-parser": "^4.18 || ^5.0",
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Library for counting the lines of code in PHP source code",
+            "homepage": "https://github.com/sebastianbergmann/lines-of-code",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/lines-of-code/issues",
+                "source": "https://github.com/sebastianbergmann/lines-of-code/tree/1.0.4"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2023-12-22T06:20:34+00:00"
+        },
+        {
+            "name": "sebastian/object-enumerator",
+            "version": "4.0.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/object-enumerator.git",
+                "reference": "5c9eeac41b290a3712d88851518825ad78f45c71"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/object-enumerator/zipball/5c9eeac41b290a3712d88851518825ad78f45c71",
+                "reference": "5c9eeac41b290a3712d88851518825ad78f45c71",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3",
+                "sebastian/object-reflector": "^2.0",
+                "sebastian/recursion-context": "^4.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "4.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Traverses array structures and object graphs to enumerate all referenced objects",
+            "homepage": "https://github.com/sebastianbergmann/object-enumerator/",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/object-enumerator/issues",
+                "source": "https://github.com/sebastianbergmann/object-enumerator/tree/4.0.4"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-10-26T13:12:34+00:00"
+        },
+        {
+            "name": "sebastian/object-reflector",
+            "version": "2.0.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/object-reflector.git",
+                "reference": "b4f479ebdbf63ac605d183ece17d8d7fe49c15c7"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/object-reflector/zipball/b4f479ebdbf63ac605d183ece17d8d7fe49c15c7",
+                "reference": "b4f479ebdbf63ac605d183ece17d8d7fe49c15c7",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Allows reflection of object attributes, including inherited and non-public ones",
+            "homepage": "https://github.com/sebastianbergmann/object-reflector/",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/object-reflector/issues",
+                "source": "https://github.com/sebastianbergmann/object-reflector/tree/2.0.4"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-10-26T13:14:26+00:00"
+        },
+        {
+            "name": "sebastian/recursion-context",
+            "version": "4.0.6",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/recursion-context.git",
+                "reference": "539c6691e0623af6dc6f9c20384c120f963465a0"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/recursion-context/zipball/539c6691e0623af6dc6f9c20384c120f963465a0",
+                "reference": "539c6691e0623af6dc6f9c20384c120f963465a0",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "4.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                },
+                {
+                    "name": "Jeff Welch",
+                    "email": "whatthejeff@gmail.com"
+                },
+                {
+                    "name": "Adam Harvey",
+                    "email": "aharvey@php.net"
+                }
+            ],
+            "description": "Provides functionality to recursively process PHP variables",
+            "homepage": "https://github.com/sebastianbergmann/recursion-context",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/recursion-context/issues",
+                "source": "https://github.com/sebastianbergmann/recursion-context/tree/4.0.6"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                },
+                {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/sebastian/recursion-context",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2025-08-10T06:57:39+00:00"
+        },
+        {
+            "name": "sebastian/resource-operations",
+            "version": "3.0.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/resource-operations.git",
+                "reference": "05d5692a7993ecccd56a03e40cd7e5b09b1d404e"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/resource-operations/zipball/05d5692a7993ecccd56a03e40cd7e5b09b1d404e",
+                "reference": "05d5692a7993ecccd56a03e40cd7e5b09b1d404e",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "3.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Provides a list of PHP built-in functions that operate on resources",
+            "homepage": "https://www.github.com/sebastianbergmann/resource-operations",
+            "support": {
+                "source": "https://github.com/sebastianbergmann/resource-operations/tree/3.0.4"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-03-14T16:00:52+00:00"
+        },
+        {
+            "name": "sebastian/type",
+            "version": "3.2.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/type.git",
+                "reference": "75e2c2a32f5e0b3aef905b9ed0b179b953b3d7c7"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/type/zipball/75e2c2a32f5e0b3aef905b9ed0b179b953b3d7c7",
+                "reference": "75e2c2a32f5e0b3aef905b9ed0b179b953b3d7c7",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.5"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.2-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Collection of value objects that represent the types of the PHP type system",
+            "homepage": "https://github.com/sebastianbergmann/type",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/type/issues",
+                "source": "https://github.com/sebastianbergmann/type/tree/3.2.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2023-02-03T06:13:03+00:00"
+        },
+        {
+            "name": "sebastian/version",
+            "version": "3.0.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/version.git",
+                "reference": "c6c1022351a901512170118436c764e473f6de8c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/version/zipball/c6c1022351a901512170118436c764e473f6de8c",
+                "reference": "c6c1022351a901512170118436c764e473f6de8c",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Library that helps with managing the version number of Git-hosted PHP projects",
+            "homepage": "https://github.com/sebastianbergmann/version",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/version/issues",
+                "source": "https://github.com/sebastianbergmann/version/tree/3.0.2"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-09-28T06:39:44+00:00"
+        },
+        {
+            "name": "theseer/tokenizer",
+            "version": "1.3.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/theseer/tokenizer.git",
+                "reference": "b7489ce515e168639d17feec34b8847c326b0b3c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/theseer/tokenizer/zipball/b7489ce515e168639d17feec34b8847c326b0b3c",
+                "reference": "b7489ce515e168639d17feec34b8847c326b0b3c",
+                "shasum": ""
+            },
+            "require": {
+                "ext-dom": "*",
+                "ext-tokenizer": "*",
+                "ext-xmlwriter": "*",
+                "php": "^7.2 || ^8.0"
+            },
+            "type": "library",
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Arne Blankerts",
+                    "email": "arne@blankerts.de",
+                    "role": "Developer"
+                }
+            ],
+            "description": "A small library for converting tokenized PHP source code into XML and potentially other formats",
+            "support": {
+                "issues": "https://github.com/theseer/tokenizer/issues",
+                "source": "https://github.com/theseer/tokenizer/tree/1.3.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/theseer",
+                    "type": "github"
+                }
+            ],
+            "time": "2025-11-17T20:03:58+00:00"
+        }
+    ],
+    "aliases": [],
+    "minimum-stability": "stable",
+    "stability-flags": {},
+    "prefer-stable": false,
+    "prefer-lowest": false,
+    "platform": {
+        "php": ">=7.4"
+    },
+    "platform-dev": {},
+    "plugin-api-version": "2.9.0"
+}

--- a/core/components/ace/documents/changelog.txt
+++ b/core/components/ace/documents/changelog.txt
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - System setting `ace.draft_restore` to save editor drafts in browser localStorage and restore after accidental reload ([#33](https://github.com/modx-pro/modx-ace/issues/33)).
 - System setting `ace.color_preview` to tint CSS color literals (#hex, rgb/hsl) in CSS/HTML modes ([#34](https://github.com/modx-pro/modx-ace/issues/34)).
 - System setting `ace.auto_close_tags` to disable automatic closing of HTML tags, brackets, and MODX tag pairs ([#29](https://github.com/modx-pro/modx-ace/issues/29)).
+- Unit tests for plugin helpers and shared JS utils (`composer test`, `npm test`).
 
 ### Fixed
 - Ctrl+S / Cmd+S in fullscreen on chunk/template/element forms: save showed success but wrote stale content because the hidden field left the form when the editor moved to `document.body`. The named input now stays in the form; `getValue()` syncs from Ace before submit; `MODx.onSaveEditor` syncs the original Ext field ([#25](https://github.com/modx-pro/modx-ace/issues/25)).

--- a/core/components/ace/elements/plugins/ace.plugin.php
+++ b/core/components/ace/elements/plugins/ace.plugin.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Ace Source Editor Plugin
  *
@@ -26,63 +27,7 @@ $corePath = $modx->getOption('ace.core_path', null, $modx->getOption('core_path'
 $ace = $modx->getService('ace', 'Ace', $corePath . 'model/ace/');
 $ace->initialize();
 
-if (!function_exists('aceGetEffectiveUseEditor')) {
-    function aceGetEffectiveUseEditor($modx) {
-        if ($modx->controller && !empty($modx->controller->context)) {
-            return (bool) $modx->controller->context->getOption('use_editor', $modx->getOption('use_editor'));
-        }
-        return (bool) $modx->getOption('use_editor');
-    }
-}
-
-if (!function_exists('aceGetEffectiveWhichEditor')) {
-    function aceGetEffectiveWhichEditor($modx) {
-        if ($modx->controller && !empty($modx->controller->context)) {
-            return trim((string) $modx->controller->context->getOption('which_editor', $modx->getOption('which_editor', '')));
-        }
-        return trim((string) $modx->getOption('which_editor', ''));
-    }
-}
-
-if (!function_exists('aceIsNonAceRichTextEditor')) {
-    function aceIsNonAceRichTextEditor($modx) {
-        $whichEditor = aceGetEffectiveWhichEditor($modx);
-        return $whichEditor !== '' && strcasecmp($whichEditor, 'Ace') !== 0;
-    }
-}
-
-if (!function_exists('aceMimeSupportsModxTags')) {
-    function aceMimeSupportsModxTags($mimeType) {
-        if ($mimeType === '' || strpos($mimeType, '@FILE:') === 0) {
-            return false;
-        }
-        static $supported = array(
-            'text/html' => true,
-            'text/x-smarty' => true,
-            'text/x-twig' => true,
-        );
-        return !empty($supported[$mimeType]);
-    }
-}
-
-if (!function_exists('aceIsResourceDataPage')) {
-    function aceIsResourceDataPage($modx) {
-        if (!$modx->controller) {
-            return false;
-        }
-        if (!empty($modx->controller->config['controller'])) {
-            $controller = strtolower(str_replace('\\', '/', $modx->controller->config['controller']));
-            if ($controller === 'resource/data') {
-                return true;
-            }
-        }
-        $action = $modx->getOption('action', $_REQUEST, '');
-        if ($action === '' && !empty($_REQUEST['a'])) {
-            $action = (string) $_REQUEST['a'];
-        }
-        return strtolower(str_replace('\\', '/', $action)) === 'resource/data';
-    }
-}
+require_once $corePath . 'includes/helpers.php';
 
 $extensionMap = array(
     'tpl'   => 'text/x-smarty',

--- a/core/components/ace/includes/helpers.php
+++ b/core/components/ace/includes/helpers.php
@@ -1,0 +1,85 @@
+<?php
+
+/**
+ * Pure helpers for Ace plugin logic (unit-tested).
+ *
+ * @package ace
+ */
+
+if (!function_exists('aceGetEffectiveUseEditor')) {
+    /**
+     * @param object $modx
+     * @return bool
+     */
+    function aceGetEffectiveUseEditor($modx) {
+        if ($modx->controller && !empty($modx->controller->context)) {
+            return (bool) $modx->controller->context->getOption('use_editor', $modx->getOption('use_editor'));
+        }
+        return (bool) $modx->getOption('use_editor');
+    }
+}
+
+if (!function_exists('aceGetEffectiveWhichEditor')) {
+    /**
+     * @param object $modx
+     * @return string
+     */
+    function aceGetEffectiveWhichEditor($modx) {
+        if ($modx->controller && !empty($modx->controller->context)) {
+            return trim((string) $modx->controller->context->getOption('which_editor', $modx->getOption('which_editor', '')));
+        }
+        return trim((string) $modx->getOption('which_editor', ''));
+    }
+}
+
+if (!function_exists('aceIsNonAceRichTextEditor')) {
+    /**
+     * @param object $modx
+     * @return bool
+     */
+    function aceIsNonAceRichTextEditor($modx) {
+        $whichEditor = aceGetEffectiveWhichEditor($modx);
+        return $whichEditor !== '' && strcasecmp($whichEditor, 'Ace') !== 0;
+    }
+}
+
+if (!function_exists('aceMimeSupportsModxTags')) {
+    /**
+     * @param string $mimeType
+     * @return bool
+     */
+    function aceMimeSupportsModxTags($mimeType) {
+        if ($mimeType === '' || strpos($mimeType, '@FILE:') === 0) {
+            return false;
+        }
+        static $supported = array(
+            'text/html' => true,
+            'text/x-smarty' => true,
+            'text/x-twig' => true,
+        );
+        return !empty($supported[$mimeType]);
+    }
+}
+
+if (!function_exists('aceIsResourceDataPage')) {
+    /**
+     * @param object $modx
+     * @return bool
+     */
+    function aceIsResourceDataPage($modx) {
+        if (!$modx->controller) {
+            return false;
+        }
+        if (!empty($modx->controller->config['controller'])) {
+            $controller = strtolower(str_replace('\\', '/', $modx->controller->config['controller']));
+            if ($controller === 'resource/data') {
+                return true;
+            }
+        }
+        $action = $modx->getOption('action', $_REQUEST, '');
+        if ($action === '' && !empty($_REQUEST['a'])) {
+            $action = (string) $_REQUEST['a'];
+        }
+        return strtolower(str_replace('\\', '/', $action)) === 'resource/data';
+    }
+}

--- a/core/components/ace/model/ace/ace.class.php
+++ b/core/components/ace/model/ace/ace.class.php
@@ -41,6 +41,7 @@ class Ace {
             $this->modx->controller->addJavascript($this->config['assetsUrl'] . 'ace/ext-language_tools.js');
             $this->modx->controller->addJavascript($this->config['assetsUrl'] . 'ace/ext-keybinding_menu.js');
             $this->modx->controller->addJavascript($this->config['assetsUrl'] . 'ace/ext-emmet.js');
+            $this->modx->controller->addJavascript($this->config['assetsUrl'] . 'ace-utils.js');
             $this->modx->controller->addJavascript($this->config['assetsUrl'] . 'modx.texteditor.js');
             $this->modx->controller->addJavascript($this->config['assetsUrl'] . 'ace-color-preview.js');
 

--- a/package.json
+++ b/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "modx-ace",
+  "private": true,
+  "description": "Ace code editor for MODX Revolution",
+  "scripts": {
+    "test": "node --test tests/js/*.test.js"
+  },
+  "engines": {
+    "node": ">=18"
+  }
+}

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.6/phpunit.xsd"
+        bootstrap="tests/php/bootstrap.php"
+        colors="true"
+        cacheResult="false">
+    <testsuites>
+        <testsuite name="Ace">
+            <directory>tests/php</directory>
+        </testsuite>
+    </testsuites>
+</phpunit>

--- a/tests/js/ace-utils.test.js
+++ b/tests/js/ace-utils.test.js
@@ -1,0 +1,91 @@
+const { describe, it } = require('node:test');
+const assert = require('node:assert/strict');
+const path = require('node:path');
+const utils = require(path.join(__dirname, '../../assets/components/ace/ace-utils.js'));
+
+describe('parseBoolSetting', () => {
+  it('uses default for empty values', () => {
+    assert.equal(utils.parseBoolSetting(undefined, true), true);
+    assert.equal(utils.parseBoolSetting(null, true), true);
+    assert.equal(utils.parseBoolSetting('', true), true);
+    assert.equal(utils.parseBoolSetting(undefined, false), false);
+  });
+
+  it('parses truthy MODX setting values', () => {
+    assert.equal(utils.parseBoolSetting(true, false), true);
+    assert.equal(utils.parseBoolSetting('1', false), true);
+    assert.equal(utils.parseBoolSetting(1, false), true);
+  });
+
+  it('parses falsy MODX setting values', () => {
+    assert.equal(utils.parseBoolSetting(false, true), false);
+    assert.equal(utils.parseBoolSetting('0', true), false);
+    assert.equal(utils.parseBoolSetting(0, true), false);
+  });
+});
+
+describe('draftStorageKey', () => {
+  it('builds stable encoded keys', () => {
+    assert.equal(
+      utils.draftStorageKey('element/chunk/update', 'modx-chunk-snippet', '12'),
+      'ace:draft:element%2Fchunk%2Fupdate:modx-chunk-snippet:12'
+    );
+  });
+
+  it('defaults missing parts without colliding with id 0', () => {
+    assert.equal(utils.draftStorageKey('', '', ''), 'ace:draft:manager:field:new');
+    assert.equal(utils.draftStorageKey('a', 'n', 0), 'ace:draft:a:n:0');
+  });
+});
+
+describe('shouldOfferDraftRestore', () => {
+  it('offers only non-empty differing drafts', () => {
+    assert.equal(utils.shouldOfferDraftRestore('new', 'old'), true);
+    assert.equal(utils.shouldOfferDraftRestore('same', 'same'), false);
+    assert.equal(utils.shouldOfferDraftRestore('', 'old'), false);
+    assert.equal(utils.shouldOfferDraftRestore(null, 'old'), false);
+  });
+});
+
+describe('normalizeCssColor', () => {
+  it('accepts hex colors', () => {
+    assert.equal(utils.normalizeCssColor('#fff'), '#fff');
+    assert.equal(utils.normalizeCssColor('#ffffff'), '#ffffff');
+    assert.equal(utils.normalizeCssColor('#ffffffff'), '#ffffffff');
+  });
+
+  it('accepts valid rgb/hsl', () => {
+    assert.equal(utils.normalizeCssColor('rgb(0,0,0)'), 'rgb(0,0,0)');
+    assert.equal(utils.normalizeCssColor('rgba(255, 128, 0, 0.5)'), 'rgba(255, 128, 0, 0.5)');
+    assert.equal(utils.normalizeCssColor('hsl(120, 50%, 50%)'), 'hsl(120, 50%, 50%)');
+  });
+
+  it('rejects invalid colors', () => {
+    assert.equal(utils.normalizeCssColor('red'), null);
+    assert.equal(utils.normalizeCssColor('#gg'), null);
+    assert.equal(utils.normalizeCssColor('rgb(999,0,0)'), null);
+    assert.equal(utils.normalizeCssColor(''), null);
+  });
+});
+
+describe('mimeSupportsColorPreview', () => {
+  it('allows css/html family mimes', () => {
+    assert.equal(utils.mimeSupportsColorPreview('text/css'), true);
+    assert.equal(utils.mimeSupportsColorPreview('text/x-scss'), true);
+    assert.equal(utils.mimeSupportsColorPreview('text/html'), true);
+  });
+
+  it('rejects php/json/empty', () => {
+    assert.equal(utils.mimeSupportsColorPreview('application/x-php'), false);
+    assert.equal(utils.mimeSupportsColorPreview('application/json'), false);
+    assert.equal(utils.mimeSupportsColorPreview(''), false);
+  });
+});
+
+describe('shouldWaitForAsyncBuffer', () => {
+  it('waits only for resource cache buffer field', () => {
+    assert.equal(utils.shouldWaitForAsyncBuffer('modx-rdata-buffer'), true);
+    assert.equal(utils.shouldWaitForAsyncBuffer('modx-chunk-snippet'), false);
+    assert.equal(utils.shouldWaitForAsyncBuffer('ta'), false);
+  });
+});

--- a/tests/php/HelpersTest.php
+++ b/tests/php/HelpersTest.php
@@ -1,0 +1,149 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+
+class AceTestModx
+{
+    public $controller = null;
+    /** @var array */
+    public $options = array();
+
+    public function __construct(array $options = array(), $controller = null)
+    {
+        $this->options = $options;
+        $this->controller = $controller;
+    }
+
+    public function getOption($key, $options = null, $default = null)
+    {
+        if (is_array($options) && array_key_exists($key, $options)) {
+            return $options[$key];
+        }
+        if (array_key_exists($key, $this->options)) {
+            return $this->options[$key];
+        }
+        return $default;
+    }
+}
+
+class AceTestContext
+{
+    /** @var array */
+    public $options = array();
+
+    public function __construct(array $options = array())
+    {
+        $this->options = $options;
+    }
+
+    public function getOption($key, $default = null)
+    {
+        if (array_key_exists($key, $this->options)) {
+            return $this->options[$key];
+        }
+        return $default;
+    }
+}
+
+class HelpersTest extends TestCase
+{
+    protected function tearDown(): void
+    {
+        $_REQUEST = array();
+        parent::tearDown();
+    }
+
+    public function testMimeSupportsModxTagsForHtmlLikeMime()
+    {
+        $this->assertTrue(aceMimeSupportsModxTags('text/html'));
+        $this->assertTrue(aceMimeSupportsModxTags('text/x-smarty'));
+        $this->assertTrue(aceMimeSupportsModxTags('text/x-twig'));
+    }
+
+    public function testMimeRejectsNonHtmlAndFileHints()
+    {
+        $this->assertFalse(aceMimeSupportsModxTags(''));
+        $this->assertFalse(aceMimeSupportsModxTags('text/x-scss'));
+        $this->assertFalse(aceMimeSupportsModxTags('text/css'));
+        $this->assertFalse(aceMimeSupportsModxTags('application/json'));
+        $this->assertFalse(aceMimeSupportsModxTags('application/x-php'));
+        $this->assertFalse(aceMimeSupportsModxTags('@FILE:style.scss'));
+    }
+
+    public function testIsNonAceRichTextEditorDetectsOtherRte()
+    {
+        $this->assertTrue(aceIsNonAceRichTextEditor(new AceTestModx(array('which_editor' => 'TinyMCE'))));
+        $this->assertTrue(aceIsNonAceRichTextEditor(new AceTestModx(array('which_editor' => 'tinymce'))));
+    }
+
+    public function testIsNonAceRichTextEditorAllowsAceOrEmpty()
+    {
+        $this->assertFalse(aceIsNonAceRichTextEditor(new AceTestModx(array('which_editor' => 'Ace'))));
+        $this->assertFalse(aceIsNonAceRichTextEditor(new AceTestModx(array('which_editor' => 'ace'))));
+        $this->assertFalse(aceIsNonAceRichTextEditor(new AceTestModx(array('which_editor' => ''))));
+        $this->assertFalse(aceIsNonAceRichTextEditor(new AceTestModx(array())));
+    }
+
+    public function testGetEffectiveUseEditorUsesGlobalWhenNoContext()
+    {
+        $this->assertTrue(aceGetEffectiveUseEditor(new AceTestModx(array('use_editor' => 1))));
+        $this->assertFalse(aceGetEffectiveUseEditor(new AceTestModx(array('use_editor' => 0))));
+    }
+
+    public function testGetEffectiveUseEditorPrefersContextOverride()
+    {
+        $controller = new stdClass();
+        $controller->context = new AceTestContext(array('use_editor' => 0));
+        $this->assertFalse(aceGetEffectiveUseEditor(new AceTestModx(array('use_editor' => 1), $controller)));
+
+        $controller->context = new AceTestContext(array('use_editor' => 1));
+        $this->assertTrue(aceGetEffectiveUseEditor(new AceTestModx(array('use_editor' => 0), $controller)));
+    }
+
+    public function testGetEffectiveWhichEditorPrefersContextOverride()
+    {
+        $controller = new stdClass();
+        $controller->context = new AceTestContext(array('which_editor' => 'TinyMCE'));
+        $modx = new AceTestModx(array('which_editor' => 'Ace'), $controller);
+        $this->assertSame('TinyMCE', aceGetEffectiveWhichEditor($modx));
+        $this->assertTrue(aceIsNonAceRichTextEditor($modx));
+    }
+
+    public function testIsResourceDataPageFromControllerConfig()
+    {
+        $controller = new stdClass();
+        $controller->config = array('controller' => 'resource/data');
+        $this->assertTrue(aceIsResourceDataPage(new AceTestModx(array(), $controller)));
+
+        $controller->config = array('controller' => 'Resource\\Data');
+        $this->assertTrue(aceIsResourceDataPage(new AceTestModx(array(), $controller)));
+    }
+
+    public function testIsResourceDataPageFromRequestAction()
+    {
+        $controller = new stdClass();
+        $controller->config = array();
+        $_REQUEST['a'] = 'resource/data';
+        $this->assertTrue(aceIsResourceDataPage(new AceTestModx(array(), $controller)));
+    }
+
+    public function testIsResourceDataPageFalseOtherwise()
+    {
+        $this->assertFalse(aceIsResourceDataPage(new AceTestModx(array())));
+
+        $controller = new stdClass();
+        $controller->config = array('controller' => 'resource/update');
+        $this->assertFalse(aceIsResourceDataPage(new AceTestModx(array(), $controller)));
+    }
+
+    public function testDefaultSnippetsFileContainsCoreTriggers()
+    {
+        $path = dirname(__DIR__, 2) . '/assets/components/ace/snippets/modx.default.snippets';
+        $this->assertFileExists($path);
+        $contents = file_get_contents($path);
+        $this->assertStringContainsString("snippet getr\n", $contents);
+        $this->assertStringContainsString("snippet pdoResources\n", $contents);
+        $this->assertStringContainsString("snippet chunk\n", $contents);
+        $this->assertStringContainsString('[[!getResources?', $contents);
+    }
+}

--- a/tests/php/bootstrap.php
+++ b/tests/php/bootstrap.php
@@ -1,0 +1,3 @@
+<?php
+
+require_once dirname(__DIR__, 2) . '/core/components/ace/includes/helpers.php';


### PR DESCRIPTION
Adds PHPUnit and Node unit tests for the critical 1.9.10 logic.

Plugin helpers live in `core/components/ace/includes/helpers.php` and are covered for mime/RTE/context/resource-data matrices. Shared browser/Node helpers live in `ace-utils.js` (bool settings, draft keys, color normalize, async wait gate).

Run: `composer install && vendor/bin/phpunit` and `npm test`.